### PR TITLE
chore(conan): BEE-30 Phase D — real v0.0.0 sha256 in conandata.yml

### DIFF
--- a/recipe/all/conandata.yml
+++ b/recipe/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.0.0":
     url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.0.0.tar.gz"
-    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    sha256: "1e07d7b704f324497f70e1181d00aed5b03fd51a2f68de5675a14a8ba168806d"


### PR DESCRIPTION
## Summary
- Update `recipe/all/conandata.yml` with the real sha256 of the `v0.0.0` source tarball from GitHub

sha256: `1e07d7b704f324497f70e1181d00aed5b03fd51a2f68de5675a14a8ba168806d`

## Test plan
- [x] sha256 verified against `curl -sL .../v0.0.0.tar.gz | shasum -a 256`

🤖 Generated with [Claude Code](https://claude.com/claude-code)