### PR TITLE
infra(ci): BEE-1690 add Windows matrix (x64 + ARM64) + MSVC Conan profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,14 +62,32 @@ jobs:
       - name: Verify lockfile is unchanged
         run: git diff --exit-code conan.lock
 
-      - name: Configure
+      - name: Configure (Unix)
+        if: runner.os != 'Windows'
         run: cmake --preset ci
 
-      - name: Build
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
         run: cmake --build --preset ci
 
-      - name: Test
+      - name: Test (Unix)
+        if: runner.os != 'Windows'
         run: ctest --preset ci
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --preset conan-default
+        shell: pwsh
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --build --preset conan-debug
+        shell: pwsh
+
+      - name: Test (Windows)
+        if: runner.os == 'Windows'
+        run: ctest --preset conan-debug --output-on-failure
+        shell: pwsh
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,8 @@ jobs:
           pip install "conan>=2.0,<3.0"
           conan --version
 
-      - name: Cache Conan packages
+      - name: Cache Conan packages (Unix)
+        if: runner.os != 'Windows'
         uses: actions/cache@v4
         with:
           path: ~/.conan2
@@ -40,8 +41,23 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
-      - name: Install Conan dependencies
+      - name: Cache Conan packages (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ~\.conan2
+          key: conan-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('conan.lock', 'conanfile.py', 'profiles/*') }}
+          restore-keys: |
+            conan-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install Conan dependencies (Unix)
+        if: runner.os != 'Windows'
         run: ./scripts/conan-install.sh Debug
+
+      - name: Install Conan dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: ./scripts/conan-install.ps1 Debug
+        shell: pwsh
 
       - name: Verify lockfile is unchanged
         run: git diff --exit-code conan.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,14 @@ target_include_directories(BeepingCore PUBLIC
 
 target_compile_features(BeepingCore PUBLIC cxx_std_20)
 
+# MSVC-specific flags:
+# - /Zc:preprocessor: enables the conformant C++11+ preprocessor (required for __VA_OPT__)
+# - /utf-8: treat sources and execution character set as UTF-8
+# Both are PUBLIC because headers use __VA_OPT__ in macros (BeepingDebug.h).
+if(MSVC)
+  target_compile_options(BeepingCore PUBLIC /Zc:preprocessor /utf-8)
+endif()
+
 # spdlog: link via imported target if external, else inject header path
 if(BEEPING_USE_EXTERNAL_SPDLOG)
   target_link_libraries(BeepingCore PRIVATE spdlog::spdlog)

--- a/include/BeepingDebug.h
+++ b/include/BeepingDebug.h
@@ -26,10 +26,19 @@ void ensureBeepingLogger();
 
 }  // namespace BEEPING
 
-// Strip path to filename only
-#define BEEPING_FILENAME_                                                  \
-  (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 \
-                                    : __FILE__)
+// Strip path to filename only (cross-platform — handles both / and \).
+// Runtime strrchr is fine for debug logging; not on hot paths.
+namespace BEEPING {
+inline const char* beeping_filename(const char* path) noexcept {
+  const char* slash = nullptr;
+  for (const char* p = path; *p; ++p) {
+    if (*p == '/' || *p == '\\') slash = p;
+  }
+  return slash ? slash + 1 : path;
+}
+}  // namespace BEEPING
+
+#define BEEPING_FILENAME_ BEEPING::beeping_filename(__FILE__)
 
 #define BTRACE(fmt, ...)                                \
   do {                                                  \

--- a/include/BeepingDebug.h
+++ b/include/BeepingDebug.h
@@ -32,7 +32,9 @@ namespace BEEPING {
 inline const char* beeping_filename(const char* path) noexcept {
   const char* slash = nullptr;
   for (const char* p = path; *p; ++p) {
-    if (*p == '/' || *p == '\\') slash = p;
+    if (*p == '/' || *p == '\\') {
+      slash = p;
+    }
   }
   return slash ? slash + 1 : path;
 }

--- a/profiles/windows-arm64
+++ b/profiles/windows-arm64
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Debug
+compiler=msvc
+compiler.version=193
+compiler.cppstd=20
+compiler.runtime=dynamic
+os=Windows

--- a/profiles/windows-x64
+++ b/profiles/windows-x64
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Debug
+compiler=msvc
+compiler.version=193
+compiler.cppstd=20
+compiler.runtime=dynamic
+os=Windows

--- a/scripts/conan-install.ps1
+++ b/scripts/conan-install.ps1
@@ -41,6 +41,7 @@ try {
     conan install . `
         --build=missing `
         --lockfile=conan.lock `
+        -of "build/$BuildType" `
         "-pr:h=$Profile" `
         "-pr:b=$Profile" `
         "-s" "build_type=$BuildType"

--- a/scripts/conan-install.ps1
+++ b/scripts/conan-install.ps1
@@ -41,7 +41,6 @@ try {
     conan install . `
         --build=missing `
         --lockfile=conan.lock `
-        -of "build/$BuildType" `
         "-pr:h=$Profile" `
         "-pr:b=$Profile" `
         "-s" "build_type=$BuildType"

--- a/scripts/conan-install.ps1
+++ b/scripts/conan-install.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+# Install Conan dependencies for beeping-core on Windows.
+#
+# Usage:
+#   .\scripts\conan-install.ps1            # Debug build (default)
+#   .\scripts\conan-install.ps1 Release    # Release build
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$BuildType = "Debug"
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..")).Path
+
+if (-not (Get-Command conan -ErrorAction SilentlyContinue)) {
+    Write-Error "❌ conan not found. Install it first: pipx install conan"
+    exit 1
+}
+
+$ConanVersion = (conan --version) -replace ".*\s(\d)", '$1'
+$ConanMajor = [int]($ConanVersion -split "\.")[0]
+if ($ConanMajor -lt 2) {
+    Write-Error "❌ Conan 2.x required, found $ConanVersion"
+    exit 1
+}
+
+# Pick profile by architecture
+$Arch = $env:PROCESSOR_ARCHITECTURE
+if ($Arch -eq "ARM64") {
+    $Profile = Join-Path $RepoRoot "profiles/windows-arm64"
+} else {
+    $Profile = Join-Path $RepoRoot "profiles/windows-x64"
+}
+
+Push-Location $RepoRoot
+try {
+    conan install . `
+        --build=missing `
+        --lockfile=conan.lock `
+        "-pr:h=$Profile" `
+        "-pr:b=$Profile" `
+        "-s" "build_type=$BuildType"
+    Write-Host "✅ Conan deps installed for build_type=$BuildType ($Arch)" -ForegroundColor Green
+} finally {
+    Pop-Location
+}

--- a/scripts/conan-install.sh
+++ b/scripts/conan-install.sh
@@ -33,6 +33,7 @@ cd "$REPO_ROOT"
 conan install . \
   --build=missing \
   --lockfile=conan.lock \
+  -of "build/$BUILD_TYPE" \
   -pr:h="$PROFILE" \
   -pr:b="$PROFILE" \
   -s build_type="$BUILD_TYPE"

--- a/scripts/conan-install.sh
+++ b/scripts/conan-install.sh
@@ -33,7 +33,6 @@ cd "$REPO_ROOT"
 conan install . \
   --build=missing \
   --lockfile=conan.lock \
-  -of "build/$BUILD_TYPE" \
   -pr:h="$PROFILE" \
   -pr:b="$PROFILE" \
   -s build_type="$BUILD_TYPE"


### PR DESCRIPTION
## Summary

- Expand CI matrix from `[ubuntu-latest, macos-latest]` to `[ubuntu-latest, macos-latest, windows-latest, windows-11-arm]`
- New Conan profiles: `profiles/windows-x64` and `profiles/windows-arm64` (MSVC 193, cppstd=20, dynamic runtime)
- New `scripts/conan-install.ps1` PowerShell equivalent (auto-selects profile by `PROCESSOR_ARCHITECTURE`)
- CI steps split per platform (bash script on Unix, pwsh script on Windows)

## Why

Blocks BEE-1682 (First Beep quest step 7 — OS select with Windows option). Without Windows CI, the quest can't offer Windows to developers confidently.

## Test plan

- [ ] GitHub Actions matrix run green on all 4 OS
- [ ] Iterate fixes based on Windows-specific issues that appear
- [ ] Merge after all 4 matrix cells pass

Linked: BEE-1690