### PR TITLE
chore(release): BEE-1674 align CMakeLists VERSION + wire extra-files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 project(BeepingCore
-  VERSION 2.0.0
+  VERSION 0.0.0 # x-release-please-version
   DESCRIPTION "C++20 library for encoding and decoding data over sound"
   HOMEPAGE_URL "https://github.com/beeping-io/beeping-core"
   LANGUAGES CXX

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
   "packages": {
     ".": {
       "package-name": "beeping-core",
+      "extra-files": ["CMakeLists.txt"],
       "changelog-sections": [
         { "type": "feat", "section": "✨ Features" },
         { "type": "fix", "section": "🐛 Bug Fixes" },


### PR DESCRIPTION
## Summary

- CMakeLists.txt VERSION \`2.0.0\` → \`0.0.0\` (Decision 10: ecosystem uses 0.x until E2E validation)
- Added \`x-release-please-version\` marker so release-please keeps CMakeLists in sync with git tags
- \`release-please-config.json\`: added \`extra-files: [\"CMakeLists.txt\"]\`

## Test plan

- [x] JSON config valid
- [x] x-release-please-version marker in CMakeLists
- [ ] CI passes
- [ ] Post-merge: on next feat/fix merge to main, release-please updates CMakeLists VERSION + CHANGELOG + tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)