### PR TITLE
release: develop → main (Phase 1 ext + macOS validation)

### DIFF
--- a/.github/workflows/cci-check.yml
+++ b/.github/workflows/cci-check.yml
@@ -1,0 +1,65 @@
+name: ConanCenter PR check
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # daily at 08:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  check:
+    name: Check CCI PR status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR and notify if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CCI_PR: "29997"
+        run: |
+          set -euo pipefail
+
+          # Fetch PR state
+          PR_JSON=$(gh pr view "$CCI_PR" \
+            --repo conan-io/conan-center-index \
+            --json state,title,updatedAt,comments,reviews \
+            --jq '{
+              state: .state,
+              title: .title,
+              updatedAt: .updatedAt,
+              commentCount: (.comments | length),
+              reviewCount: (.reviews | length)
+            }')
+
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+          UPDATED=$(echo "$PR_JSON" | jq -r '.updatedAt')
+          COMMENTS=$(echo "$PR_JSON" | jq -r '.commentCount')
+          REVIEWS=$(echo "$PR_JSON" | jq -r '.reviewCount')
+
+          echo "## ConanCenter PR #$CCI_PR status" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| State | $STATE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Last updated | $UPDATED |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Comments | $COMMENTS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reviews | $REVIEWS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Calculate hours since last update
+          UPDATED_TS=$(date -d "$UPDATED" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
+          NOW_TS=$(date +%s)
+          HOURS_AGO=$(( (NOW_TS - UPDATED_TS) / 3600 ))
+
+          if [ "$STATE" = "MERGED" ]; then
+            echo "🎉 **PR MERGED!** ConanCenter recipe is live." >> "$GITHUB_STEP_SUMMARY"
+            echo "→ Run: conan search beeping-core -r=conancenter" >> "$GITHUB_STEP_SUMMARY"
+            echo "→ TODO: update docs/conan.md, add badge to README, close BEE-30" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$STATE" = "CLOSED" ]; then
+            echo "❌ **PR CLOSED** without merge. Check feedback and reopen." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$HOURS_AGO" -lt 24 ]; then
+            echo "🔔 **Activity in last 24h** — check for reviewer comments or CI results." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "😴 No activity in ${HOURS_AGO}h. Still waiting for CCI review." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "[View PR](https://github.com/conan-io/conan-center-index/pull/$CCI_PR)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,8 @@ jobs:
           pip install "conan>=2.0,<3.0"
           conan --version
 
-      - name: Cache Conan packages
+      - name: Cache Conan packages (Unix)
+        if: runner.os != 'Windows'
         uses: actions/cache@v4
         with:
           path: ~/.conan2
@@ -40,20 +41,53 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
-      - name: Install Conan dependencies
+      - name: Cache Conan packages (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ~\.conan2
+          key: conan-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('conan.lock', 'conanfile.py', 'profiles/*') }}
+          restore-keys: |
+            conan-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install Conan dependencies (Unix)
+        if: runner.os != 'Windows'
         run: ./scripts/conan-install.sh Debug
+
+      - name: Install Conan dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: ./scripts/conan-install.ps1 Debug
+        shell: pwsh
 
       - name: Verify lockfile is unchanged
         run: git diff --exit-code conan.lock
 
-      - name: Configure
+      - name: Configure (Unix)
+        if: runner.os != 'Windows'
         run: cmake --preset ci
 
-      - name: Build
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
         run: cmake --build --preset ci
 
-      - name: Test
+      - name: Test (Unix)
+        if: runner.os != 'Windows'
         run: ctest --preset ci
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --preset conan-default
+        shell: pwsh
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --build --preset conan-debug
+        shell: pwsh
+
+      - name: Test (Windows)
+        if: runner.os == 'Windows'
+        run: ctest --preset conan-debug --output-on-failure
+        shell: pwsh
 
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=ON \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
             -DCMAKE_INSTALL_PREFIX=install
 
@@ -43,8 +44,18 @@ jobs:
       - name: Install
         run: cmake --install build
 
-      - name: Verify architectures
+      - name: Verify lib universal
         run: lipo -info install/lib/libBeepingCore.a
+
+      - name: Verify CLI binary universal
+        run: |
+          test -x install/bin/beeping-core || { echo "❌ CLI binary missing at install/bin/beeping-core"; exit 1; }
+          lipo -info install/bin/beeping-core
+
+      - name: Smoke-test CLI
+        run: |
+          install/bin/beeping-core --help
+          install/bin/beeping-core --version
 
       - name: Package
         run: |
@@ -52,6 +63,13 @@ jobs:
           tar --zstd -cf ../beeping-core-macos-universal.tar.zst .
           cd ..
           shasum -a 256 beeping-core-macos-universal.tar.zst > beeping-core-macos-universal.sha256
+
+      - name: Verify CLI in tarball
+        run: |
+          mkdir verify
+          tar --zstd -xf beeping-core-macos-universal.tar.zst -C verify
+          test -x verify/bin/beeping-core || { echo "❌ CLI binary missing in packaged tarball"; exit 1; }
+          verify/bin/beeping-core --help
 
       - uses: actions/upload-artifact@v4
         with:
@@ -65,6 +83,8 @@ jobs:
   # ---------------------------------------------------------------------------
   linux-amd64:
     name: Linux amd64
+    # BEE-1729 — re-enable when Ubuntu + Linux Docker compat matrix validated E2E
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -105,6 +125,8 @@ jobs:
   # ---------------------------------------------------------------------------
   linux-arm64:
     name: Linux arm64
+    # BEE-1696 — re-enable when Linux ARM64 / Raspberry Pi validated E2E
+    if: false
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -145,6 +167,8 @@ jobs:
   # ---------------------------------------------------------------------------
   android:
     name: Android NDK (${{ matrix.abi }})
+    # Phase 8 — re-enable when beeping-android SDK task validates end-to-end
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -198,6 +222,8 @@ jobs:
   # ---------------------------------------------------------------------------
   ios:
     name: iOS XCFramework
+    # Phase 9 — re-enable when beeping-ios SDK task validates end-to-end
+    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -256,6 +282,8 @@ jobs:
   # ---------------------------------------------------------------------------
   wasm:
     name: WASM (Emscripten)
+    # BEE-1731 — re-enable when WASM browser E2E QA validated
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -328,7 +356,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-arm64, android, ios, wasm, sbom]
+    needs: [macos, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -368,7 +396,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-arm64, android, ios, wasm, sbom]
+    needs: [macos, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BUILD_TESTING "Build tests" ON)
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
+option(BEEPING_BUILD_CLI "Build the `beeping-core` CLI binary" ON)
 option(BEEPING_ENABLE_TSAN "Build with ThreadSanitizer (Clang/GCC only)" OFF)
 option(BEEPING_ENABLE_ASAN "Build with AddressSanitizer" OFF)
 option(BEEPING_ENABLE_UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
@@ -155,16 +156,27 @@ FetchContent_MakeAvailable(Catch2)
 if(BUILD_TESTING)
   enable_testing()
 
-  add_executable(BeepingCoreTests
+  set(BEEPING_TEST_SOURCES
     tests/UnitTests.cpp
     tests/RoundTripTests.cpp
     tests/ConcurrencyTests.cpp
   )
+  if(BEEPING_BUILD_CLI)
+    list(APPEND BEEPING_TEST_SOURCES tests/CLIIntegrationTest.cpp)
+  endif()
+
+  add_executable(BeepingCoreTests ${BEEPING_TEST_SOURCES})
   target_link_libraries(BeepingCoreTests PRIVATE BeepingCore Catch2::Catch2WithMain)
   target_include_directories(BeepingCoreTests PRIVATE
     ${spdlog_SOURCE_DIR}/include
   )
   target_compile_definitions(BeepingCoreTests PRIVATE SPDLOG_HEADER_ONLY)
+  if(BEEPING_BUILD_CLI)
+    add_dependencies(BeepingCoreTests beeping_core_cli)
+    target_compile_definitions(BeepingCoreTests PRIVATE
+      BEEPING_CLI_BINARY="$<TARGET_FILE:beeping_core_cli>"
+    )
+  endif()
   if(NOT WIN32)
     target_link_libraries(BeepingCoreTests PRIVATE pthread)
   endif()
@@ -183,6 +195,12 @@ if(BUILD_TESTING)
 endif()
 
 # --- Benchmarks (Google Benchmark) ---
+
+# --- CLI binary ---
+
+if(BEEPING_BUILD_CLI)
+  add_subdirectory(cli)
+endif()
 
 option(BEEPING_BUILD_BENCHMARKS "Build performance benchmarks" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,14 @@ target_include_directories(BeepingCore PUBLIC
 
 target_compile_features(BeepingCore PUBLIC cxx_std_20)
 
+# MSVC-specific flags:
+# - /Zc:preprocessor: enables the conformant C++11+ preprocessor (required for __VA_OPT__)
+# - /utf-8: treat sources and execution character set as UTF-8
+# Both are PUBLIC because headers use __VA_OPT__ in macros (BeepingDebug.h).
+if(MSVC)
+  target_compile_options(BeepingCore PUBLIC /Zc:preprocessor /utf-8)
+endif()
+
 # spdlog: link via imported target if external, else inject header path
 if(BEEPING_USE_EXTERNAL_SPDLOG)
   target_link_libraries(BeepingCore PRIVATE spdlog::spdlog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 project(BeepingCore
-  VERSION 2.0.0
+  VERSION 0.0.0 # x-release-please-version
   DESCRIPTION "C++20 library for encoding and decoding data over sound"
   HOMEPAGE_URL "https://github.com/beeping-io/beeping-core"
   LANGUAGES CXX

--- a/README.md
+++ b/README.md
@@ -59,10 +59,42 @@ be run before `cmake --preset` for the matching build type.
 
 ### Conan profiles
 
-Project-managed profiles live in [`profiles/`](profiles/) (`macos`, `linux`).
-The install script auto-selects by `uname -s`. Pinning the profiles in-repo
-keeps CI and local builds bit-for-bit reproducible regardless of the host
-default profile.
+Project-managed profiles live in [`profiles/`](profiles/):
+`macos`, `linux`, `windows-x64`, `windows-arm64`.
+
+- On macOS/Linux the install script (`scripts/conan-install.sh`) picks the
+  profile by `uname -s`.
+- On Windows use `scripts/conan-install.ps1` (PowerShell), which picks
+  `windows-x64` or `windows-arm64` based on `$env:PROCESSOR_ARCHITECTURE`.
+
+Pinning the profiles in-repo keeps CI and local builds bit-for-bit
+reproducible regardless of the host default profile.
+
+## CLI — decode a WAV
+
+The build produces a `beeping-core` binary (at
+`build/Debug/cli/beeping-core`) that can decode a WAV file produced by
+the Beeping platform:
+
+```bash
+./build/Debug/cli/beeping-core version
+# BeepingCoreLib version 1.0.0 [...]
+
+./build/Debug/cli/beeping-core decode audio.wav
+# payload-string
+
+./build/Debug/cli/beeping-core decode -m 2 audio.wav   # force audible
+./build/Debug/cli/beeping-core decode -m 3 audio.wav   # force inaudible
+# default is -m 5 (try both)
+```
+
+Exit codes: `0` = decoded (payload on stdout), `1` = no beep found,
+`2` = bad input (missing file, unreadable WAV, etc.).
+
+Supports WAV PCM int16 (format 1) and IEEE float 32-bit (format 3),
+mono or stereo (downmixed to mono).
+
+Full docs: [`docs/cli.md`](docs/cli.md).
 
 ## Releases & verification
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ C++20 library for encoding and decoding data over sound (Data Over Sound).
 [![Static Analysis](https://github.com/beeping-io/beeping-core/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/beeping-io/beeping-core/actions/workflows/static-analysis.yml)
 [![Docs](https://github.com/beeping-io/beeping-core/actions/workflows/docs.yml/badge.svg)](https://core-docs.beeping.io)
 
+<!-- Platform validation status -->
+![macOS](https://img.shields.io/badge/🍎_macOS-validated-brightgreen)
+![Linux](https://img.shields.io/badge/🐧_Linux-coming_soon-lightgrey)
+![Windows](https://img.shields.io/badge/🪟_Windows-coming_soon-lightgrey)
+![WASM](https://img.shields.io/badge/🌐_WASM-coming_soon-lightgrey)
+![iOS](https://img.shields.io/badge/📱_iOS-Phase_9-lightgrey)
+![Android](https://img.shields.io/badge/🤖_Android-Phase_8-lightgrey)
+
+> **Cross-platform strategy**: each OS is validated end-to-end (download
+> tarball → run CLI → round-trip test) before being promoted to the release.
+> "Validated" = we've actually used it on that platform and it works.
+> See [docs/INSTALL.md](docs/INSTALL.md) for installation per platform.
+
 ## Requirements
 
 - C++20 compiler (Apple Clang 15+, GCC 13+, Clang 16+)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(beeping_core_cli
+  beeping_cli_main.cpp
+  decode_cmd.cpp
+  wav_reader.cpp
+)
+
+set_target_properties(beeping_core_cli PROPERTIES
+  OUTPUT_NAME "beeping-core"
+)
+
+target_link_libraries(beeping_core_cli PRIVATE BeepingCore)
+target_compile_features(beeping_core_cli PRIVATE cxx_std_20)
+
+install(TARGETS beeping_core_cli
+  RUNTIME DESTINATION bin
+)

--- a/cli/beeping_cli_main.cpp
+++ b/cli/beeping_cli_main.cpp
@@ -1,0 +1,64 @@
+// beeping-core CLI — entry point.
+//
+// Usage:
+//   beeping-core decode <audio.wav>   Decode a WAV to stdout
+//   beeping-core version              Print library + server versions
+//   beeping-core help                 Show this help
+
+#include <BeepingCoreLib_api.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "decode_cmd.h"
+
+namespace {
+
+int print_help() {
+  std::printf(
+      "beeping-core — CLI for the Beeping data-over-sound library.\n"
+      "\n"
+      "Usage:\n"
+      "  beeping-core decode [OPTIONS] <audio.wav>\n"
+      "  beeping-core version\n"
+      "  beeping-core help\n"
+      "\n"
+      "Commands:\n"
+      "  decode     Decode a WAV file and print the payload to stdout.\n"
+      "  version    Print the BeepingCore library version.\n"
+      "  help       Show this help.\n"
+      "\n"
+      "Run 'beeping-core decode --help' for decode-specific options.\n");
+  return 0;
+}
+
+int print_version() {
+  std::printf("%s\n", BEEPING_GetVersion());
+  return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    return print_help();
+  }
+
+  const std::string cmd = argv[1];
+  if (cmd == "help" || cmd == "--help" || cmd == "-h") {
+    return print_help();
+  }
+  if (cmd == "version" || cmd == "--version" || cmd == "-v") {
+    return print_version();
+  }
+  if (cmd == "decode") {
+    // Forward remaining args (starting at argv[2]) to decode_cmd.
+    return beeping::cli::decode_cmd(argc - 2, argv + 2);
+  }
+
+  std::fprintf(stderr,
+               "Error: unknown command '%s'. Try 'beeping-core help'.\n",
+               cmd.c_str());
+  return 2;
+}

--- a/cli/decode_cmd.cpp
+++ b/cli/decode_cmd.cpp
@@ -1,0 +1,155 @@
+#include "decode_cmd.h"
+
+#include <BeepingCoreLib_api.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "wav_reader.h"
+
+namespace beeping::cli {
+
+namespace {
+
+constexpr int kDefaultMode = BEEPING_MODE_ALL;  // tries audible + inaudible
+constexpr int kBufferSize = 1024;
+
+void print_decode_help() {
+  std::fprintf(stderr,
+               "Usage: beeping-core decode [OPTIONS] <audio.wav>\n"
+               "\n"
+               "Decode a WAV file produced by beeping-core or beepbox.\n"
+               "\n"
+               "Options:\n"
+               "  -m, --mode N   Decode mode: 2=audible, 3=inaudible, 5=all "
+               "(default: 5)\n"
+               "  -h, --help     Show this help\n"
+               "\n"
+               "Exit codes:\n"
+               "  0  decoded successfully (payload on stdout)\n"
+               "  1  no beep decoded in the audio\n"
+               "  2  invalid input / unreadable WAV\n");
+}
+
+}  // namespace
+
+int decode_cmd(int argc, char** argv) {
+  int mode = kDefaultMode;
+  std::string path;
+
+  for (int i = 0; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "-h" || arg == "--help") {
+      print_decode_help();
+      return 0;
+    }
+    if (arg == "-m" || arg == "--mode") {
+      if (i + 1 >= argc) {
+        std::fprintf(stderr, "Error: --mode requires an argument\n");
+        return 2;
+      }
+      try {
+        mode = std::stoi(argv[++i]);
+      } catch (...) {
+        std::fprintf(stderr, "Error: --mode must be an integer\n");
+        return 2;
+      }
+      if (mode != BEEPING_MODE_AUDIBLE && mode != BEEPING_MODE_INAUDIBLE &&
+          mode != BEEPING_MODE_ALL) {
+        std::fprintf(stderr,
+                     "Error: --mode must be 2 (audible), 3 (inaudible) or 5 "
+                     "(all)\n");
+        return 2;
+      }
+    } else if (!arg.empty() && arg[0] != '-') {
+      if (!path.empty()) {
+        std::fprintf(stderr, "Error: multiple input files not supported\n");
+        return 2;
+      }
+      path = arg;
+    } else {
+      std::fprintf(stderr, "Error: unknown option '%s'\n", arg.c_str());
+      return 2;
+    }
+  }
+
+  if (path.empty()) {
+    print_decode_help();
+    return 2;
+  }
+
+  WavData wav;
+  if (std::string err = read_wav_file(path, wav); !err.empty()) {
+    std::fprintf(stderr, "Error reading WAV: %s\n", err.c_str());
+    return 2;
+  }
+  if (wav.samples.empty()) {
+    std::fprintf(stderr, "Error: WAV contains no audio samples\n");
+    return 2;
+  }
+
+  void* handle = BEEPING_Create();
+  if (!handle) {
+    std::fprintf(stderr, "Error: BEEPING_Create failed\n");
+    return 2;
+  }
+
+  if (BEEPING_Configure(mode, wav.sample_rate, kBufferSize, handle) != 0) {
+    std::fprintf(stderr,
+                 "Error: BEEPING_Configure failed for mode=%d sr=%.0f\n", mode,
+                 wav.sample_rate);
+    BEEPING_Destroy(handle);
+    return 2;
+  }
+
+  bool word_decoded = false;
+  for (std::size_t i = 0; i < wav.samples.size(); i += kBufferSize) {
+    int chunk = static_cast<int>(
+        std::min<std::size_t>(kBufferSize, wav.samples.size() - i));
+    int result = BEEPING_DecodeAudioBuffer(wav.samples.data() + i, chunk,
+                                           handle);
+    if (result == -3) {
+      word_decoded = true;
+      break;
+    }
+  }
+
+  // If not decoded yet, flush with silence to push remaining frames through
+  // the decoder's internal buffer (up to ~5s of audio at 44.1kHz).
+  if (!word_decoded) {
+    std::vector<float> silence(kBufferSize, 0.0f);
+    for (int flush = 0; flush < 200; ++flush) {
+      int result =
+          BEEPING_DecodeAudioBuffer(silence.data(), kBufferSize, handle);
+      if (result == -3) {
+        word_decoded = true;
+        break;
+      }
+    }
+  }
+
+  int exit_code = 1;
+  if (word_decoded) {
+    char decoded[32] = {0};
+    int len = BEEPING_GetDecodedData(decoded, handle);
+    if (len > 0 && len < static_cast<int>(sizeof(decoded))) {
+      decoded[len] = '\0';
+      std::fwrite(decoded, 1, static_cast<std::size_t>(len), stdout);
+      std::fputc('\n', stdout);
+      exit_code = 0;
+    } else if (len < 0) {
+      std::fprintf(
+          stderr,
+          "Warning: decoded data failed integrity checks (length=%d)\n",
+          -len);
+      exit_code = 1;
+    }
+  }
+
+  BEEPING_Destroy(handle);
+  return exit_code;
+}
+
+}  // namespace beeping::cli

--- a/cli/decode_cmd.h
+++ b/cli/decode_cmd.h
@@ -1,0 +1,15 @@
+#ifndef BEEPING_CLI_DECODE_CMD_H
+#define BEEPING_CLI_DECODE_CMD_H
+
+namespace beeping::cli {
+
+// Runs the `decode` subcommand.
+// Exit codes:
+//   0 = decoded successfully (payload printed to stdout)
+//   1 = audio processed but nothing decoded (no valid beep found)
+//   2 = invalid input (bad args, missing file, unreadable WAV, etc.)
+int decode_cmd(int argc, char** argv);
+
+}  // namespace beeping::cli
+
+#endif  // BEEPING_CLI_DECODE_CMD_H

--- a/cli/wav_reader.cpp
+++ b/cli/wav_reader.cpp
@@ -1,0 +1,138 @@
+#include "wav_reader.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace beeping::cli {
+
+namespace {
+
+struct Chunk {
+  char id[4];
+  uint32_t size;
+};
+
+bool read_exact(std::ifstream& f, void* buf, std::size_t n) {
+  f.read(static_cast<char*>(buf), static_cast<std::streamsize>(n));
+  return f.good();
+}
+
+bool id_equals(const char id[4], const char* expected) {
+  return std::memcmp(id, expected, 4) == 0;
+}
+
+}  // namespace
+
+std::string read_wav_file(const std::string& path, WavData& out) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) {
+    return "cannot open file: " + path;
+  }
+
+  // RIFF header
+  char riff[4];
+  uint32_t file_size = 0;
+  char wave[4];
+  if (!read_exact(f, riff, 4) || !read_exact(f, &file_size, 4) ||
+      !read_exact(f, wave, 4)) {
+    return "truncated RIFF header";
+  }
+  if (!id_equals(riff, "RIFF") || !id_equals(wave, "WAVE")) {
+    return "not a RIFF/WAVE file";
+  }
+
+  // Find fmt and data chunks
+  uint16_t audio_format = 0;
+  uint16_t channels = 0;
+  uint32_t sample_rate = 0;
+  uint16_t bits_per_sample = 0;
+  std::vector<char> pcm_data;
+  bool fmt_seen = false;
+  bool data_seen = false;
+
+  while (f && !(fmt_seen && data_seen)) {
+    Chunk chunk{};
+    if (!read_exact(f, chunk.id, 4) || !read_exact(f, &chunk.size, 4)) {
+      break;
+    }
+    if (id_equals(chunk.id, "fmt ")) {
+      if (chunk.size < 16) return "fmt chunk too small";
+      uint16_t block_align = 0;
+      uint32_t byte_rate = 0;
+      if (!read_exact(f, &audio_format, 2) || !read_exact(f, &channels, 2) ||
+          !read_exact(f, &sample_rate, 4) || !read_exact(f, &byte_rate, 4) ||
+          !read_exact(f, &block_align, 2) ||
+          !read_exact(f, &bits_per_sample, 2)) {
+        return "truncated fmt chunk";
+      }
+      // Skip any extra bytes in the fmt chunk
+      if (chunk.size > 16) {
+        f.seekg(chunk.size - 16, std::ios::cur);
+      }
+      fmt_seen = true;
+    } else if (id_equals(chunk.id, "data")) {
+      pcm_data.resize(chunk.size);
+      if (!read_exact(f, pcm_data.data(), chunk.size)) {
+        return "truncated data chunk";
+      }
+      data_seen = true;
+    } else {
+      // Skip unknown chunk, pad byte if odd
+      f.seekg(chunk.size + (chunk.size & 1u), std::ios::cur);
+    }
+  }
+
+  if (!fmt_seen || !data_seen) {
+    return "missing fmt or data chunk";
+  }
+  if (audio_format != 1 && audio_format != 3) {
+    return "only PCM integer (1) or IEEE float (3) supported, got format " +
+           std::to_string(audio_format);
+  }
+  if (channels < 1 || channels > 2) {
+    return "only mono or stereo supported, got " + std::to_string(channels) +
+           " channels";
+  }
+  if (audio_format == 1 && bits_per_sample != 16) {
+    return "PCM integer only supports 16-bit, got " +
+           std::to_string(bits_per_sample) + " bits";
+  }
+  if (audio_format == 3 && bits_per_sample != 32) {
+    return "IEEE float only supports 32-bit, got " +
+           std::to_string(bits_per_sample) + " bits";
+  }
+
+  const std::size_t bytes_per_sample = bits_per_sample / 8;
+  const std::size_t frames = pcm_data.size() / (bytes_per_sample * channels);
+  out.samples.resize(frames);
+
+  if (audio_format == 1) {
+    const auto* int16_data = reinterpret_cast<const int16_t*>(pcm_data.data());
+    for (std::size_t i = 0; i < frames; ++i) {
+      int32_t sum = 0;
+      for (int c = 0; c < channels; ++c) {
+        sum += int16_data[i * channels + c];
+      }
+      out.samples[i] = static_cast<float>(sum) / (channels * 32768.0f);
+    }
+  } else {
+    // IEEE float 32-bit
+    const auto* f32_data = reinterpret_cast<const float*>(pcm_data.data());
+    for (std::size_t i = 0; i < frames; ++i) {
+      float sum = 0.0f;
+      for (int c = 0; c < channels; ++c) {
+        sum += f32_data[i * channels + c];
+      }
+      out.samples[i] = sum / static_cast<float>(channels);
+    }
+  }
+  out.sample_rate = static_cast<float>(sample_rate);
+  out.channels = channels;
+  return {};
+}
+
+}  // namespace beeping::cli

--- a/cli/wav_reader.h
+++ b/cli/wav_reader.h
@@ -1,0 +1,24 @@
+#ifndef BEEPING_CLI_WAV_READER_H
+#define BEEPING_CLI_WAV_READER_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace beeping::cli {
+
+struct WavData {
+  std::vector<float> samples;  // mono, normalized to [-1.0, 1.0]
+  float sample_rate = 0.0f;
+  int channels = 0;
+};
+
+// Parses a canonical RIFF WAV file (PCM 16-bit). Returns empty error string
+// on success, else a human-readable message. Mono or stereo accepted; stereo
+// is downmixed by averaging channels. Samples are converted from int16 to
+// float in [-1.0, 1.0].
+std::string read_wav_file(const std::string& path, WavData& out);
+
+}  // namespace beeping::cli
+
+#endif  // BEEPING_CLI_WAV_READER_H

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -1,0 +1,56 @@
+# 💡 Ideas
+
+Captura **ideas no maduras**: brainstorms, "what if we...", spikes pendientes
+de explorar, ocurrencias que no son aún una tarea formal.
+
+🌱 **Aquí entra**: cualquier ocurrencia, incluso si suena rara — todas son bienvenidas.
+🚫 **Aquí NO entra**: trabajo ya decidido y agendado a un milestone (eso va a Linear).
+
+🪄 **Promoción**: ponerle un milestone a una idea la convierte en task Linear
+`BEE-XXXX` y se elimina automáticamente de este fichero.
+
+---
+
+## 📋 Cómo añadir una idea
+
+Usa el skill `/ideas` (recomendado). O copia este bloque al final del fichero:
+
+```markdown
+### 💡 idea-NNN — [Título corto]
+
+- 📅 **Fecha**: YYYY-MM-DD
+- 🏷️ **Tipo**: feat | fix | docs | refactor | chore | infra | security | test
+- 🧭 **Contexto**: una frase de por qué surgió
+- 🎯 **Idea**: lo que se propone
+- 📝 **Notas**: detalles adicionales (opcional)
+- 🚦 **Estado**: 🌱 Nueva
+```
+
+### 🏷️ Tipos disponibles
+
+| Tipo | Cuándo usarlo |
+|------|---------------|
+| `feat` | Funcionalidad nueva |
+| `fix` | Bug fix |
+| `docs` | Solo documentación |
+| `refactor` | Refactor sin cambio de comportamiento |
+| `chore` | Mantenimiento, deps, config |
+| `infra` | Infraestructura, CI/CD |
+| `security` | Cuestiones de seguridad |
+| `test` | Solo tests |
+
+### 🚦 Estados posibles
+
+| Iconito | Estado | Significado |
+|---------|--------|-------------|
+| 🌱 | Nueva | Recién capturada, sin discusión |
+| 🔄 | En discusión | Hablándose |
+| 📋 | Promovida | Ya es task Linear (`BEE-XXXX`) — debería haberse eliminado de aquí |
+| 🧊 | En hielo | Buena idea pero no es momento |
+| ❌ | Descartada | Decidido no avanzar (apuntar el porqué) |
+
+---
+
+## 🗂️ Ideas registradas
+
+> _Aún no hay ideas. Añade la primera con `/ideas`._

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,77 @@
+# Installing beeping-core
+
+> **Status**: macOS validated end-to-end (v0.1.0). Other platforms are built
+> and shipped only after they pass their own end-to-end validation. No
+> assumptions, one OS at a time.
+
+| Platform | Status | Latest release |
+|---|---|---|
+| 🍎 macOS (universal arm64 + x86_64) | ✅ Validated | v0.1.0 |
+| 🐧 Linux (glibc distros) | ⏳ Coming | — |
+| 🪟 Windows (x64) | ⏳ Coming | — |
+| 🌐 WASM (browser) | ⏳ Coming | — |
+| 🪟 Windows ARM64 | ⏳ Coming | — |
+| 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
+| 📱 iOS XCFramework | ⏳ Phase 9 | — |
+| 🤖 Android NDK | ⏳ Phase 8 | — |
+
+## 🍎 macOS (universal — arm64 + x86_64)
+
+Runs natively on both Apple Silicon (M1/M2/M3/M4) and Intel Macs, no Rosetta
+needed. The same binary is fat-packaged with both architectures.
+
+### Download
+
+Replace `v0.1.0` with the latest release tag:
+
+```bash
+TAG=v0.1.0
+curl -LO "https://github.com/beeping-io/beeping-core/releases/download/${TAG}/beeping-core-macos-universal.tar.zst"
+curl -LO "https://github.com/beeping-io/beeping-core/releases/download/${TAG}/SHA256SUMS.txt"
+```
+
+### Verify
+
+```bash
+shasum -a 256 -c SHA256SUMS.txt --ignore-missing
+```
+
+Expected: `beeping-core-macos-universal.tar.zst: OK`.
+
+### Extract
+
+```bash
+tar --zstd -xf beeping-core-macos-universal.tar.zst
+```
+
+You now have a `bin/` and `lib/` + `include/` directory.
+
+### Run the CLI
+
+```bash
+./bin/beeping-core --help
+./bin/beeping-core --version
+```
+
+Verify it's truly universal:
+
+```bash
+lipo -info ./bin/beeping-core
+# Output: Architectures in the fat file: ./bin/beeping-core are: x86_64 arm64
+```
+
+### Decode a WAV
+
+```bash
+./bin/beeping-core decode path/to/sound.wav
+```
+
+## Other platforms
+
+Each platform goes through its own validation task before release. Track
+progress in the [project roadmap](../docs/ROADMAP.md).
+
+## Building from source
+
+Also supported — see the [Development guide](./DEVELOPMENT.md) (coming with
+first Linux validation).

--- a/docs/PENDING.md
+++ b/docs/PENDING.md
@@ -1,0 +1,57 @@
+# ⏳ Pending
+
+Captura **trabajo conocido pero aún sin fecha** — el "lo haremos algún día pero
+no ahora".
+
+🎯 **Aquí entra**: deuda detectada, follow-ups de incidentes, feedback accionable,
+"esto hay que hacerlo pero no hemos decidido cuándo".
+🚫 **Aquí NO entra**: trabajo ya agendado a un milestone (eso va a Linear).
+
+🪄 **Promoción**: ponerle un milestone a un pending lo convierte en task Linear
+`BEE-XXXX` y se elimina automáticamente de este fichero.
+
+---
+
+## 📋 Cómo añadir un pending
+
+Usa el skill `/pending` (recomendado). O copia este bloque al final del fichero:
+
+```markdown
+### ⏳ pending-NNN — [Título corto]
+
+- 📅 **Fecha añadida**: YYYY-MM-DD
+- 🏷️ **Tipo**: feat | fix | docs | refactor | chore | infra | security | test
+- 🧭 **Trigger**: por qué se añadió (incidente, feedback, deuda)
+- ⚙️ **Acción requerida**: qué hay que hacer concretamente
+- 🚧 **Bloqueado por**: (si aplica) algo o alguien que retrasa
+- 🚦 **Estado**: 🆕 Nuevo
+```
+
+### 🏷️ Tipos disponibles
+
+| Tipo | Cuándo usarlo |
+|------|---------------|
+| `feat` | Funcionalidad nueva |
+| `fix` | Bug fix |
+| `docs` | Solo documentación |
+| `refactor` | Refactor sin cambio de comportamiento |
+| `chore` | Mantenimiento, deps, config |
+| `infra` | Infraestructura, CI/CD |
+| `security` | Cuestiones de seguridad |
+| `test` | Solo tests |
+
+### 🚦 Estados posibles
+
+| Iconito | Estado | Significado |
+|---------|--------|-------------|
+| 🆕 | Nuevo | Recién capturado, sin triage |
+| 🔍 | En triage | Decidiendo prioridad / scope |
+| 📋 | Promovido | Ya es task Linear (`BEE-XXXX`) — debería haberse eliminado de aquí |
+| 🚧 | Bloqueado | Esperando algo externo (especificar) |
+| ❌ | No procede | Decidido no avanzar (apuntar el porqué) |
+
+---
+
+## 🗂️ Pendientes registrados
+
+> _Aún no hay pendings. Añade el primero con `/pending`._

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,102 @@
+# `beeping-core` CLI
+
+The `beeping-core` binary is a thin wrapper around the C++ library. It lets
+you decode a WAV file locally without writing any code — useful for debugging,
+verifying an encoded payload round-trips, or closing the loop in a Beeping
+tutorial (e.g. the [First Beep quest](https://beeping.io/quest)).
+
+## Install
+
+Build the library from source (see [the main README](../README.md)) —
+the binary is built alongside the library and ends up in
+`build/<BuildType>/cli/beeping-core` (or `beeping-core.exe` on Windows).
+
+Install system-wide with:
+
+```bash
+cmake --install build/Release --prefix /usr/local
+```
+
+## Commands
+
+### `decode`
+
+Decode a WAV file and print the payload to stdout.
+
+```text
+beeping-core decode [OPTIONS] <audio.wav>
+
+Options:
+  -m, --mode N   2 = audible, 3 = inaudible, 5 = all (default: 5)
+  -h, --help     Show this help
+```
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| `0` | Decoded successfully — payload on stdout |
+| `1` | No beep detected in the audio |
+| `2` | Invalid input (missing file, unreadable WAV, bad args) |
+
+**Supported WAV formats:**
+
+- PCM integer, 16-bit (format 1)
+- IEEE float, 32-bit (format 3)
+- Mono or stereo (stereo is downmixed by channel averaging)
+- Any sample rate supported by BeepingCore (commonly 44100, 48000, 96000 Hz)
+
+**Example:**
+
+```bash
+beeping-core decode message.wav
+# hello
+echo "exit=$?"
+# exit=0
+```
+
+### `version`
+
+Print the BeepingCore library version and exit.
+
+```bash
+beeping-core version
+# BeepingCoreLib version 1.0.0 [20220426]
+```
+
+### `help`
+
+Print the top-level help.
+
+```bash
+beeping-core help
+```
+
+## Round-trip with `beepbox` cloud
+
+A full end-to-end round-trip (requires a Beeping API key):
+
+```bash
+# 1. Encode via the cloud beepbox API
+curl -X POST https://api.beeping.io/v1/encode \
+  -H "Authorization: Bearer bk_XXXXXXXX" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "a1b2c", "mode": "inaudible"}' \
+  -o output.wav
+
+# 2. Decode locally with beeping-core
+beeping-core decode -m 3 output.wav
+# a1b2c
+```
+
+## Troubleshooting
+
+**`cannot open file: X`** — check the path and file permissions.
+
+**`only PCM integer (1) or IEEE float (3) supported`** — the WAV file uses
+an unsupported format. Re-encode to 16-bit PCM or 32-bit float WAV with
+a tool like `ffmpeg -i input.wav -c:a pcm_s16le out.wav`.
+
+**Exit code 1 (no beep)** — the audio likely doesn't contain a Beeping
+signal in the selected mode. Try `-m 5` (tries both audible and inaudible)
+or verify the recording captured the full beep sequence.

--- a/include/BeepingDebug.h
+++ b/include/BeepingDebug.h
@@ -26,10 +26,21 @@ void ensureBeepingLogger();
 
 }  // namespace BEEPING
 
-// Strip path to filename only
-#define BEEPING_FILENAME_                                                  \
-  (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 \
-                                    : __FILE__)
+// Strip path to filename only (cross-platform — handles both / and \).
+// Runtime strrchr is fine for debug logging; not on hot paths.
+namespace BEEPING {
+inline const char* beeping_filename(const char* path) noexcept {
+  const char* slash = nullptr;
+  for (const char* p = path; *p; ++p) {
+    if (*p == '/' || *p == '\\') {
+      slash = p;
+    }
+  }
+  return slash ? slash + 1 : path;
+}
+}  // namespace BEEPING
+
+#define BEEPING_FILENAME_ BEEPING::beeping_filename(__FILE__)
 
 #define BTRACE(fmt, ...)                                \
   do {                                                  \

--- a/profiles/windows-arm64
+++ b/profiles/windows-arm64
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Debug
+compiler=msvc
+compiler.version=193
+compiler.cppstd=20
+compiler.runtime=dynamic
+os=Windows

--- a/profiles/windows-x64
+++ b/profiles/windows-x64
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Debug
+compiler=msvc
+compiler.version=193
+compiler.cppstd=20
+compiler.runtime=dynamic
+os=Windows

--- a/recipe/all/conandata.yml
+++ b/recipe/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.0.0":
     url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.0.0.tar.gz"
-    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    sha256: "1e07d7b704f324497f70e1181d00aed5b03fd51a2f68de5675a14a8ba168806d"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
   "packages": {
     ".": {
       "package-name": "beeping-core",
+      "extra-files": ["CMakeLists.txt"],
       "changelog-sections": [
         { "type": "feat", "section": "✨ Features" },
         { "type": "fix", "section": "🐛 Bug Fixes" },

--- a/scripts/conan-install.ps1
+++ b/scripts/conan-install.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+# Install Conan dependencies for beeping-core on Windows.
+#
+# Usage:
+#   .\scripts\conan-install.ps1            # Debug build (default)
+#   .\scripts\conan-install.ps1 Release    # Release build
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$BuildType = "Debug"
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..")).Path
+
+if (-not (Get-Command conan -ErrorAction SilentlyContinue)) {
+    Write-Error "❌ conan not found. Install it first: pipx install conan"
+    exit 1
+}
+
+$ConanVersion = (conan --version) -replace ".*\s(\d)", '$1'
+$ConanMajor = [int]($ConanVersion -split "\.")[0]
+if ($ConanMajor -lt 2) {
+    Write-Error "❌ Conan 2.x required, found $ConanVersion"
+    exit 1
+}
+
+# Pick profile by architecture
+$Arch = $env:PROCESSOR_ARCHITECTURE
+if ($Arch -eq "ARM64") {
+    $Profile = Join-Path $RepoRoot "profiles/windows-arm64"
+} else {
+    $Profile = Join-Path $RepoRoot "profiles/windows-x64"
+}
+
+Push-Location $RepoRoot
+try {
+    conan install . `
+        --build=missing `
+        --lockfile=conan.lock `
+        "-pr:h=$Profile" `
+        "-pr:b=$Profile" `
+        "-s" "build_type=$BuildType"
+    Write-Host "✅ Conan deps installed for build_type=$BuildType ($Arch)" -ForegroundColor Green
+} finally {
+    Pop-Location
+}

--- a/tests/CLIIntegrationTest.cpp
+++ b/tests/CLIIntegrationTest.cpp
@@ -1,0 +1,210 @@
+// CLIIntegrationTest.cpp — round-trip test of the `beeping-core` CLI.
+//
+// Generates audio with the encoder, writes it as a 16-bit PCM WAV, then
+// runs the CLI binary as a subprocess to decode the WAV and checks that
+// the payload round-trips correctly.
+
+#include <BeepingCoreLib_api.h>
+
+#include <algorithm>
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifndef BEEPING_CLI_BINARY
+#error "BEEPING_CLI_BINARY must be defined (CMake should inject the path)."
+#endif
+
+#ifdef _WIN32
+#define POPEN _popen
+#define PCLOSE _pclose
+#else
+#include <sys/wait.h>
+#define POPEN popen
+#define PCLOSE pclose
+#endif
+
+namespace {
+
+bool write_wav_float32_mono(const std::string& path,
+                            const std::vector<float>& samples,
+                            int sample_rate) {
+  // Write IEEE float 32-bit (WAV format 3) — no quantization loss.
+  std::ofstream f(path, std::ios::binary);
+  if (!f) return false;
+
+  const auto num_samples = static_cast<uint32_t>(samples.size());
+  const uint32_t data_bytes = num_samples * sizeof(float);
+  const uint32_t riff_size = 36 + data_bytes;
+  const uint16_t channels = 1;
+  const uint16_t bits = 32;
+  const uint16_t block_align = 4;
+  const uint32_t byte_rate = static_cast<uint32_t>(sample_rate) * 4;
+  const uint16_t fmt = 3;  // IEEE float
+  const uint32_t fmt_size = 16;
+  const auto sr = static_cast<uint32_t>(sample_rate);
+
+  auto w = [&](const void* p, std::size_t n) {
+    f.write(static_cast<const char*>(p), static_cast<std::streamsize>(n));
+  };
+  w("RIFF", 4);
+  w(&riff_size, 4);
+  w("WAVE", 4);
+  w("fmt ", 4);
+  w(&fmt_size, 4);
+  w(&fmt, 2);
+  w(&channels, 2);
+  w(&sr, 4);
+  w(&byte_rate, 4);
+  w(&block_align, 2);
+  w(&bits, 2);
+  w("data", 4);
+  w(&data_bytes, 4);
+  for (float s : samples) {
+    w(&s, 4);
+  }
+  return f.good();
+}
+
+std::vector<float> encode_to_samples(int mode, float sample_rate,
+                                     const char* payload) {
+  void* encoder = BEEPING_Create();
+  REQUIRE(encoder != nullptr);
+  REQUIRE(BEEPING_Configure(mode, sample_rate, 1024, encoder) == 0);
+  const int len = static_cast<int>(std::strlen(payload));
+  const int total = BEEPING_EncodeDataToAudioBuffer(payload, len, 0, nullptr,
+                                                    0, encoder);
+  REQUIRE(total > 0);
+  std::vector<float> audio;
+  audio.reserve(static_cast<std::size_t>(total));
+  std::vector<float> buf(1024);
+  while (true) {
+    int n = BEEPING_GetEncodedAudioBuffer(buf.data(), encoder);
+    if (n <= 0) break;
+    audio.insert(audio.end(), buf.begin(), buf.begin() + n);
+    if (n < 1024) break;
+  }
+  BEEPING_Destroy(encoder);
+  return audio;
+}
+
+std::pair<int, std::string> run_cli(const std::string& args) {
+  // On Windows, `cmd.exe /c` strips the outermost quotes when the command
+  // starts with `"` and ends with `"`, which breaks commands that have both
+  // a quoted binary path AND a quoted argument. Wrap in an extra pair of
+  // quotes to survive that strip.
+#ifdef _WIN32
+  std::string full = "\"\"" + std::string(BEEPING_CLI_BINARY) + "\" " + args +
+                     " 2>&1\"";
+#else
+  std::string full = "\"" + std::string(BEEPING_CLI_BINARY) + "\" " + args +
+                     " 2>&1";
+#endif
+  FILE* pipe = POPEN(full.c_str(), "r");
+  REQUIRE(pipe != nullptr);
+  std::array<char, 256> buf{};
+  std::string output;
+  while (std::fgets(buf.data(), static_cast<int>(buf.size()), pipe) !=
+         nullptr) {
+    output += buf.data();
+  }
+  int rc = PCLOSE(pipe);
+#ifndef _WIN32
+  if (WIFEXITED(rc)) rc = WEXITSTATUS(rc);
+#endif
+  return {rc, output};
+}
+
+}  // namespace
+
+TEST_CASE("CLI: version command prints library version", "[cli]") {
+  auto [rc, out] = run_cli("version");
+  REQUIRE(rc == 0);
+  REQUIRE(out.find("BeepingCoreLib") != std::string::npos);
+}
+
+TEST_CASE("CLI: help command exits cleanly", "[cli]") {
+  auto [rc, out] = run_cli("help");
+  REQUIRE(rc == 0);
+  REQUIRE(out.find("beeping-core") != std::string::npos);
+}
+
+TEST_CASE("CLI: missing file returns exit code 2", "[cli]") {
+  auto [rc, out] =
+      run_cli("decode /definitely/not/a/real/file/path/xyz.wav");
+  REQUIRE(rc == 2);
+  REQUIRE(out.find("cannot open") != std::string::npos);
+}
+
+TEST_CASE("CLI: no args shows help without failing", "[cli]") {
+  auto [rc, out] = run_cli("");
+  REQUIRE(rc == 0);
+  REQUIRE(out.find("Usage") != std::string::npos);
+}
+
+TEST_CASE("WAV round-trip without CLI subprocess", "[wav][roundtrip]") {
+  constexpr float kSampleRate = 44100.0f;
+  const char* payload = "123456789";
+  auto samples = encode_to_samples(BEEPING_MODE_AUDIBLE, kSampleRate, payload);
+  INFO("Encoder produced " << samples.size() << " samples");
+  auto wav_path = std::filesystem::temp_directory_path() /
+                  "beeping_wav_roundtrip_test.wav";
+  REQUIRE(write_wav_float32_mono(wav_path.string(), samples,
+                                 static_cast<int>(kSampleRate)));
+
+  // Decode the samples we just wrote — verifies encoder output itself works
+  void* dec = BEEPING_Create();
+  REQUIRE(dec != nullptr);
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_AUDIBLE, kSampleRate, 1024, dec) == 0);
+  bool found = false;
+  for (std::size_t i = 0; i < samples.size(); i += 1024) {
+    int n = static_cast<int>(std::min<std::size_t>(1024, samples.size() - i));
+    if (BEEPING_DecodeAudioBuffer(samples.data() + i, n, dec) == -3) {
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    std::vector<float> silence(1024, 0.0f);
+    for (int k = 0; k < 200; ++k) {
+      if (BEEPING_DecodeAudioBuffer(silence.data(), 1024, dec) == -3) {
+        found = true;
+        break;
+      }
+    }
+  }
+  REQUIRE(found);
+  char decoded[32] = {0};
+  int len = BEEPING_GetDecodedData(decoded, dec);
+  INFO("Decoded directly: '" << std::string(decoded, decoded + std::max(0, len))
+                              << "' len=" << len);
+  BEEPING_Destroy(dec);
+  REQUIRE(len > 0);
+  std::filesystem::remove(wav_path);
+}
+
+TEST_CASE("CLI: decode round-trip audible mode", "[cli][roundtrip]") {
+  constexpr float kSampleRate = 44100.0f;
+  const char* payload = "123456789";
+
+  auto samples = encode_to_samples(BEEPING_MODE_AUDIBLE, kSampleRate, payload);
+  auto wav_path = std::filesystem::temp_directory_path() /
+                  "beeping_cli_audible_test.wav";
+  REQUIRE(write_wav_float32_mono(wav_path.string(), samples,
+                                 static_cast<int>(kSampleRate)));
+
+  auto [rc, out] = run_cli("decode -m 2 \"" + wav_path.string() + "\"");
+  INFO("CLI output: " << out);
+  REQUIRE(rc == 0);
+  REQUIRE(out.find(payload) != std::string::npos);
+
+  std::filesystem::remove(wav_path);
+}


### PR DESCRIPTION
## Summary

Promote \`develop\` to \`main\` to trigger release-please for v0.1.0.

### feat: commits in this promotion
- \`feat(cli)\`: BEE-1689 beeping-core CLI with decode command
- \`feat(release)\`: BEE-1694 scope release.yml to macOS-only + iterative per-OS strategy

### Other (no version bump)
- \`infra(ci)\`: BEE-1690 Windows matrix (x64 + ARM64) + MSVC Conan profiles
- \`ci(conan)\`: BEE-30 daily ConanCenter PR status check
- \`chore(conan)\`: BEE-30 conandata.yml updates
- \`chore(release)\`: BEE-1674 release-please config + CMakeLists VERSION alignment

## Expected outcome after merge
release-please opens PR \`chore(main): release 0.1.0\` with:
- CHANGELOG.md entry
- CMakeLists.txt VERSION 0.0.0 → 0.1.0
- Manifest 0.0.0 → 0.1.0

Merging that PR creates tag \`v0.1.0\` → release.yml builds macOS universal artifacts (other OS jobs disabled per BEE-1694) → publishes GitHub Release v0.1.0.

## Validation already done
- ✅ BEE-1694 E2E QA: macOS universal CLI + round-trip with beepbox in dev + prod (BEE-1694 Linear comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)