### PR TITLE
fix(release): BEE-1729 build Linux on ubuntu-22.04 + static-libstdc++

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,11 @@ jobs:
   # ---------------------------------------------------------------------------
   linux-amd64:
     name: Linux amd64
-    runs-on: ubuntu-latest
+    # ubuntu-22.04 = glibc 2.35 (baseline). Forward-compatible with Ubuntu
+    # 22.04+, Debian 12+, Fedora 41+, Arch (all have glibc >= 2.35). If we
+    # built on ubuntu-latest (24.04, glibc 2.39) the binary would fail to
+    # load on older distros — discovered in BEE-1729 first smoke matrix run.
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -97,6 +101,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
             -DBEEPING_BUILD_CLI=ON \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DCMAKE_INSTALL_PREFIX=install
 
       - name: Build


### PR DESCRIPTION
## Summary

Discovered in v0.2.0-rc1 smoke: binary built on \`ubuntu-latest\` (24.04, glibc 2.39) fails on **Debian 12** (glibc 2.36) and **Ubuntu 22.04** (glibc 2.35) with \`GLIBC_2.38 not found\` + \`GLIBCXX_3.4.31/32 not found\`.

## Fix
- Build on \`ubuntu-22.04\` runner (glibc 2.35 baseline) — forward-compatible with newer distros
- Add \`-static-libgcc -static-libstdc++\` linker flags — eliminates libstdc++ runtime dependency entirely

## Why
glibc is forward-compatible: a binary built against glibc 2.35 runs on systems with 2.35+. The opposite (2.39 binary on 2.36 host) breaks. Building on oldest supported runner is standard portable-binary practice (used by Rust, kubectl, GitHub CLI, etc.).

## Test plan
- [ ] CI passes
- [ ] Post-merge: workflow_dispatch v0.2.0-rc2 → all 5 smoke matrix distros pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)