### PR TITLE
fix(release): BEE-1730 cmake install path for Windows multi-config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
         shell: pwsh
 
       - name: Install
-        run: cmake --install build\Release --config Release --prefix install
+        run: cmake --install build --config Release --prefix install
         shell: pwsh
 
       - name: Verify CLI binary exists + static CRT


### PR DESCRIPTION
## Issue
v0.3.0-rc1 Windows job failed: `CMake Error: Not a file: D:/a/beeping-core/beeping-core/build/Release/cmake_install.cmake`

## Fix
`cmake --install build\Release` → `cmake --install build`. For multi-config generators (MSBuild on Windows), the build directory is just `build`; `--config Release` tells CMake which configuration to install.

## Test plan
- [ ] CI passes
- [ ] workflow_dispatch v0.3.0-rc2 → Windows x64 zip built

🤖 Generated with [Claude Code](https://claude.com/claude-code)