### PR TITLE
fix(release): BEE-1730 include Windows zip in GitHub Release + cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -629,7 +629,8 @@ jobs:
       - name: Sign binaries (cosign keyless)
         run: |
           cd artifacts
-          for f in *.tar.zst; do
+          for f in *.tar.zst *.zip; do
+            [ -f "$f" ] || continue
             cosign sign-blob --yes --output-signature "$f.sig" "$f"
           done
 
@@ -648,6 +649,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/*.tar.zst
+            artifacts/*.zip
             artifacts/*.sig
             artifacts/beeping-core-sbom.cdx.json
             artifacts/SHA256SUMS.txt

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | 🍎 macOS (universal arm64 + x86_64) | ✅ Validated | v0.1.0 |
 | 🐧 Linux amd64 (glibc — Ubuntu 22+/24+, Debian 12+, Fedora 41+, Arch) | ✅ Validated | v0.2.0 |
-| 🪟 Windows 11 (x64) | ✅ Validated | v0.3.0 |
+| 🪟 Windows 11 (x64) | ✅ Validated | v0.3.1 |
 | 🌐 WASM (browser) | ⏳ Coming | — |
 | 🪟 Windows ARM64 | ⏳ Coming | — |
 | 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
@@ -114,10 +114,10 @@ Validated end-to-end on **Windows 11**. Built with MSVC + **static CRT** (`/MT`)
 
 ### Download
 
-Replace `v0.3.0` with the latest release tag:
+Replace `v0.3.1` with the latest release tag:
 
 ```powershell
-$tag = "v0.3.0"
+$tag = "v0.3.1"
 Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/beeping-core-windows-x64.zip" -OutFile beeping-core-windows-x64.zip
 Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/SHA256SUMS.txt" -OutFile SHA256SUMS.txt
 ```


### PR DESCRIPTION
## Summary

v0.3.0 was cut with a green Release workflow, but its GitHub Release is missing `beeping-core-windows-x64.zip` because:

1. **Publish job `files:`** only lists `artifacts/*.tar.zst` — the Windows `.zip` was uploaded as a CI artifact but never attached to the release.
2. **cosign sign-blob loop** only iterates `*.tar.zst`, so the Windows zip would not be signed anyway.

This PR adds `*.zip` to both lists. The next tag (`v0.3.1`) will ship Windows alongside macOS and Linux with matching keyless cosign signatures and SHA256SUMS entries.

`docs/INSTALL.md` is bumped to reference `v0.3.1` as the Windows-validated tag.

Part of **BEE-1730**. v0.3.0 remains as-is (correct macOS + Linux, no destructive retag).

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.3.1` → release.yml publishes with 3 OS artifacts + 3 cosign `.sig`
- [ ] Run `gh release view v0.3.1 --json assets` to confirm `beeping-core-windows-x64.zip` and `beeping-core-windows-x64.zip.sig` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)