### PR TITLE
fix(ci): BEE-1696 remove orphan line in arm64 compat-smoke block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,7 +572,6 @@ jobs:
               /opt/bin/beeping-core --version
               echo '✅ ${{ matrix.image }} arm64 OK'
             "
-            beeping-core-linux-arm64.sha256
 
   # ---------------------------------------------------------------------------
   # Android NDK — arm64-v8a, armeabi-v7a, x86_64


### PR DESCRIPTION
## Summary

`v0.6.0-rc1` had all 5 `linux-arm64-compat-smoke` matrix entries exit 127 with:

```
/home/runner/work/_temp/XXX.sh: line 15: beeping-core-linux-arm64.sha256: command not found
```

The in-container docker smoke printed `✅ <distro> arm64 OK` successfully first — the failure was the outer runner shell trying to execute the orphan `beeping-core-linux-arm64.sha256` line that slipped into the block after the `sh -c "..."` closing quote.

Delete the orphan. No behavioural change, the docker smoke itself is already green.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: re-dispatch `release.yml` with `v0.6.0-rc2` → all 5 arm64 compat-smoke entries should pass cleanly
- [ ] Cut `v0.6.0` → close BEE-1696

🤖 Generated with [Claude Code](https://claude.com/claude-code)