### PR TITLE
fix(ci): BEE-1696 drop archlinux from arm64 compat-smoke matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,12 +544,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Arch Linux is x86_64-only upstream (Arch Linux ARM is a separate
+        # project with a different image) — omitted from this matrix. The
+        # four distros below cover every realistic Pi/arm64 deployment.
         image:
           - ubuntu:22.04
           - ubuntu:24.04
           - debian:12
           - fedora:41
-          - archlinux:latest
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -185,9 +185,10 @@ If your ARM64 Windows is running an x64 build of `beeping-core` under Prism emul
 
 Validated end-to-end on the GitHub-hosted **`ubuntu-22.04-arm`** runner and
 smoke-tested against Ubuntu 22.04/24.04, Debian 12 (== Raspberry Pi OS
-bookworm base), Fedora 41 and Arch — all arm64. Built against glibc 2.35 +
+bookworm base) and Fedora 41 — all arm64. Built against glibc 2.35 +
 `-static-libgcc -static-libstdc++`, so the binary runs on any arm64 Linux
-with glibc 2.35+.
+with glibc 2.35+. Arch Linux ARM is a separate community project; the
+binary should also run there but it isn't part of the smoke matrix.
 
 Supported hardware:
 


### PR DESCRIPTION
## Summary

`v0.6.0-rc2` passed 4/5 arm64 compat-smoke entries; archlinux failed with:

```
docker: no matching manifest for linux/arm64 in the manifest list entries
```

Arch Linux upstream publishes only an x86_64 `archlinux:latest` image. Arch Linux ARM is a separate community project with a different image, so it doesn't belong in this matrix. Keep archlinux in the amd64 smoke matrix; drop it only from arm64.

The remaining four distros (Ubuntu 22.04 / 24.04, Debian 12 == Raspberry Pi OS bookworm base, Fedora 41) cover every realistic Pi/arm64 deployment.

## Test plan

- [ ] CI green on this PR
- [ ] Re-dispatch `release.yml` with `v0.6.0-rc3` → all 4 arm64 compat-smoke entries pass
- [ ] Cut `v0.6.0` → close BEE-1696

🤖 Generated with [Claude Code](https://claude.com/claude-code)