### PR TITLE
feat(release): BEE-2221 Android NDK .so artifacts (16 KB pages)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -577,11 +577,17 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Android NDK — arm64-v8a, armeabi-v7a, x86_64
+  #
+  # Builds shared `libbeepingcore.so` per ABI with 16 KB page-size alignment
+  # (required by Android 15+ for apps published after Nov 2025) and
+  # minSdkVersion=24 to match beeping-android (BEE-2221).
+  #
+  # OUTPUT_NAME is forced to lowercase on Android via CMakeLists.txt so the
+  # produced file is `libbeepingcore.so`, matching the JNI loader call
+  # `System.loadLibrary("beepingcore")` in beeping-android/AndroidBeepingCore.
   # ---------------------------------------------------------------------------
   android:
     name: Android NDK (${{ matrix.abi }})
-    # Phase 8 — re-enable when beeping-android SDK task validates end-to-end
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -591,23 +597,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd binutils
 
       - name: Setup Android NDK
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26d
+          ndk-version: r27c
 
       - name: Configure
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_SHARED_LIBS=ON \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
             -DANDROID_ABI=${{ matrix.abi }} \
-            -DANDROID_PLATFORM=android-21 \
+            -DANDROID_PLATFORM=android-24 \
+            -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384" \
             -DCMAKE_INSTALL_PREFIX=install
 
       - name: Build
@@ -615,6 +623,27 @@ jobs:
 
       - name: Install
         run: cmake --install build
+
+      - name: Verify libbeepingcore.so + 16 KB alignment (readelf)
+        run: |
+          set -e
+          SO=$(find install -name "libbeepingcore.so" | head -1)
+          test -f "$SO" || { echo "❌ libbeepingcore.so missing at expected path"; find install -type f; exit 1; }
+          test -d install/include || { echo "❌ include/ headers missing in install tree"; exit 1; }
+          echo "Found: $SO"
+          file "$SO"
+          readelf -l "$SO" | tee /tmp/elf.txt
+          # Every PT_LOAD segment must align to >= 0x4000 (16 KB) for Android 15+.
+          # Earlier alignments (0x1000 / 4 KB) trigger UnsatisfiedLinkError on
+          # 16 KB-page devices: "program alignment (4096) cannot be smaller
+          # than system page size (16384)".
+          BAD=$(awk '/^  LOAD/ {print $NF}' /tmp/elf.txt | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
+          if [ -n "$BAD" ]; then
+            echo "❌ ${{ matrix.abi }}: LOAD segments with align < 0x4000 detected:"
+            echo "$BAD"
+            exit 1
+          fi
+          echo "✅ ${{ matrix.abi }}: all LOAD segments aligned to >= 16 KB"
 
       - name: Package
         run: |
@@ -629,6 +658,48 @@ jobs:
           path: |
             beeping-core-android-${{ matrix.abi }}.tar.zst
             beeping-core-android-${{ matrix.abi }}.sha256
+
+  # ---------------------------------------------------------------------------
+  # Android smoke — re-verify each just-published tarball, end-to-end:
+  # extract, confirm shape (libbeepingcore.so + include/ headers), and
+  # re-run the readelf 16 KB alignment assertion against the *packaged*
+  # binary (defends against any packaging step that might strip metadata).
+  # ---------------------------------------------------------------------------
+  android-smoke:
+    name: Android smoke (${{ matrix.abi }})
+    needs: [android]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86_64]
+    steps:
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y zstd binutils
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: beeping-core-android-${{ matrix.abi }}
+          path: artifact
+
+      - name: Extract + verify shape + readelf
+        run: |
+          set -e
+          mkdir -p verify
+          tar --zstd -xf artifact/beeping-core-android-${{ matrix.abi }}.tar.zst -C verify
+          echo "=== tarball contents ==="
+          find verify -maxdepth 4 -type f
+          SO=$(find verify -name "libbeepingcore.so" | head -1)
+          test -f "$SO" || { echo "❌ libbeepingcore.so missing in extracted tarball"; exit 1; }
+          test -d verify/include || { echo "❌ include/ headers missing in extracted tarball"; exit 1; }
+          file "$SO"
+          readelf -l "$SO" | grep -E "^  (LOAD|Type)"
+          BAD=$(readelf -l "$SO" | awk '/^  LOAD/ {print $NF}' | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
+          if [ -n "$BAD" ]; then
+            echo "❌ Tarball ${{ matrix.abi }}: LOAD segment with align < 16 KB: $BAD"
+            exit 1
+          fi
+          echo "✅ ${{ matrix.abi }} tarball OK: libbeepingcore.so + include/ + 16 KB aligned"
 
   # ---------------------------------------------------------------------------
   # iOS — XCFramework (device + simulator)
@@ -789,7 +860,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -829,7 +900,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,12 +632,17 @@ jobs:
           test -d install/include || { echo "❌ include/ headers missing in install tree"; exit 1; }
           echo "Found: $SO"
           file "$SO"
-          readelf -l "$SO" | tee /tmp/elf.txt
+          # -W (wide) prints each program header on a single line so $NF is
+          # always the Align field, regardless of address width (32 vs 64 bit).
+          readelf -W -l "$SO" | tee /tmp/elf.txt
           # Every PT_LOAD segment must align to >= 0x4000 (16 KB) for Android 15+.
           # Earlier alignments (0x1000 / 4 KB) trigger UnsatisfiedLinkError on
           # 16 KB-page devices: "program alignment (4096) cannot be smaller
           # than system page size (16384)".
-          BAD=$(awk '/^  LOAD/ {print $NF}' /tmp/elf.txt | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
+          ALIGNS=$(awk '/^  LOAD/ {print $NF}' /tmp/elf.txt)
+          test -n "$ALIGNS" || { echo "❌ no LOAD segments parsed"; exit 1; }
+          echo "Detected LOAD aligns: $ALIGNS"
+          BAD=$(echo "$ALIGNS" | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
           if [ -n "$BAD" ]; then
             echo "❌ ${{ matrix.abi }}: LOAD segments with align < 0x4000 detected:"
             echo "$BAD"
@@ -693,8 +698,10 @@ jobs:
           test -f "$SO" || { echo "❌ libbeepingcore.so missing in extracted tarball"; exit 1; }
           test -d verify/include || { echo "❌ include/ headers missing in extracted tarball"; exit 1; }
           file "$SO"
-          readelf -l "$SO" | grep -E "^  (LOAD|Type)"
-          BAD=$(readelf -l "$SO" | awk '/^  LOAD/ {print $NF}' | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
+          readelf -W -l "$SO" | grep "^  LOAD"
+          ALIGNS=$(readelf -W -l "$SO" | awk '/^  LOAD/ {print $NF}')
+          test -n "$ALIGNS" || { echo "❌ no LOAD segments parsed"; exit 1; }
+          BAD=$(echo "$ALIGNS" | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
           if [ -n "$BAD" ]; then
             echo "❌ Tarball ${{ matrix.abi }}: LOAD segment with align < 16 KB: $BAD"
             exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,13 @@ set(BEEPING_CORE_SOURCES
 
 add_library(BeepingCore ${BEEPING_CORE_SOURCES})
 
+# Android JNI loads the library via System.loadLibrary("beepingcore") which
+# resolves to libbeepingcore.so. Force the output name to lowercase only on
+# Android so other platforms keep libBeepingCore.{a,so,dylib,dll} unchanged.
+if(ANDROID)
+  set_target_properties(BeepingCore PROPERTIES OUTPUT_NAME "beepingcore")
+endif()
+
 target_include_directories(BeepingCore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -10,9 +10,9 @@
 | 🍎 macOS | arm64 + x86_64 universal | `beeping-core-macos-universal.tar.zst` |
 | 🐧 Linux | amd64 | `beeping-core-linux-amd64.tar.zst` |
 | 🐧 Linux | arm64 | `beeping-core-linux-arm64.tar.zst` |
-| 🤖 Android NDK | arm64-v8a | `beeping-core-android-arm64-v8a.tar.zst` |
-| 🤖 Android NDK | armeabi-v7a | `beeping-core-android-armeabi-v7a.tar.zst` |
-| 🤖 Android NDK | x86_64 | `beeping-core-android-x86_64.tar.zst` |
+| 🤖 Android NDK | arm64-v8a (16 KB pages, minSdk 24) | `beeping-core-android-arm64-v8a.tar.zst` |
+| 🤖 Android NDK | armeabi-v7a (16 KB pages, minSdk 24) | `beeping-core-android-armeabi-v7a.tar.zst` |
+| 🤖 Android NDK | x86_64 (16 KB pages, minSdk 24) | `beeping-core-android-x86_64.tar.zst` |
 | 🍎 iOS | device + simulator | `beeping-core-ios-xcframework.tar.zst` |
 | 🌐 WASM | Emscripten | `beeping-core-wasm.tar.zst` |
 
@@ -56,6 +56,14 @@ tar --zstd -xf beeping-core-macos-universal.tar.zst
 # iOS (XCFramework)
 tar --zstd -xf beeping-core-ios-xcframework.tar.zst
 # Now you have: BeepingCore.xcframework — drag into Xcode
+
+# Android NDK (one tarball per ABI)
+tar --zstd -xf beeping-core-android-arm64-v8a.tar.zst
+# Now you have: lib/libbeepingcore.so + include/BeepingCoreLib_api.h
+# The .so is built with -Wl,-z,max-page-size=16384 for Android 15+ 16 KB pages
+# and named lowercase to match System.loadLibrary("beepingcore"). Drop into
+# app/src/main/jniLibs/<abi>/libbeepingcore.so. See docs/verifying-releases.md
+# section 5 for the readelf 16 KB alignment check.
 ```
 
 ## Triggering a release

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -227,15 +227,20 @@ cosign verify-blob \
 # 3. Extract and inspect ELF program headers
 mkdir -p extract && tar --zstd -xf $ARTIFACT -C extract
 SO=$(find extract -name "libbeepingcore.so" | head -1)
-readelf -l "$SO" | grep "^  LOAD"
+readelf -W -l "$SO" | grep "^  LOAD"
 ```
 
-Each `LOAD` segment must show alignment `>= 0x4000` (16 KB):
+Use `readelf -W` (wide) so each program header is printed on a single
+line — the default output splits a LOAD record across two lines, which
+hides the Align column.
+
+Each `LOAD` segment must show alignment `>= 0x4000` (16 KB) in the last
+column:
 
 ```
-  LOAD           0x000000 ... 0x004000 R   0x4000   ✅ 16 KB OK
-  LOAD           0x004000 ... 0x004000 R E 0x4000   ✅
-  LOAD           0x010000 ... 0x004000 RW  0x4000   ✅
+  LOAD  0x000000 0x00000000 0x00000000 0x13a270 0x13a270 R E 0x4000   ✅
+  LOAD  0x13a270 0x0013e270 0x0013e270 0x00a2e0 0x00ad90 RW  0x4000   ✅
+  LOAD  0x144550 0x0014c550 0x0014c550 0x0002e8 0x002440 RW  0x4000   ✅
 ```
 
 If you see `0x1000` (4 KB) instead, the binary will fail to load at runtime

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -237,7 +237,7 @@ hides the Align column.
 Each `LOAD` segment must show alignment `>= 0x4000` (16 KB) in the last
 column:
 
-```
+```text
   LOAD  0x000000 0x00000000 0x00000000 0x13a270 0x13a270 R E 0x4000   ✅
   LOAD  0x13a270 0x0013e270 0x0013e270 0x00a2e0 0x00ad90 RW  0x4000   ✅
   LOAD  0x144550 0x0014c550 0x0014c550 0x0002e8 0x002440 RW  0x4000   ✅
@@ -246,7 +246,7 @@ column:
 If you see `0x1000` (4 KB) instead, the binary will fail to load at runtime
 on Android 15+ devices with the error:
 
-```
+```text
 java.lang.UnsatisfiedLinkError: dlopen failed:
 "libbeepingcore.so" program alignment (4096) cannot be smaller than
 system page size (16384)

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -202,6 +202,58 @@ echo "✅ All verifications passed for $ARTIFACT"
 
 ---
 
+## 5. 🤖 Android-specific: 16 KB page-size verification
+
+Android 15+ enforces 16 KB memory pages on apps published after Nov 2025.
+The Android NDK shared libraries shipped by `beeping-core`
+(`beeping-core-android-{arm64-v8a,armeabi-v7a,x86_64}.tar.zst`) are linked
+with `-Wl,-z,max-page-size=16384`, but you can re-confirm it locally with
+`readelf` from `binutils`.
+
+```bash
+# 1. Download + extract a per-ABI tarball
+ABI=arm64-v8a   # or armeabi-v7a, x86_64
+ARTIFACT=beeping-core-android-$ABI.tar.zst
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+
+# 2. (Recommended) verify cosign signature first — same flow as section 2
+cosign verify-blob \
+  --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --signature $ARTIFACT.sig \
+  $ARTIFACT
+
+# 3. Extract and inspect ELF program headers
+mkdir -p extract && tar --zstd -xf $ARTIFACT -C extract
+SO=$(find extract -name "libbeepingcore.so" | head -1)
+readelf -l "$SO" | grep "^  LOAD"
+```
+
+Each `LOAD` segment must show alignment `>= 0x4000` (16 KB):
+
+```
+  LOAD           0x000000 ... 0x004000 R   0x4000   ✅ 16 KB OK
+  LOAD           0x004000 ... 0x004000 R E 0x4000   ✅
+  LOAD           0x010000 ... 0x004000 RW  0x4000   ✅
+```
+
+If you see `0x1000` (4 KB) instead, the binary will fail to load at runtime
+on Android 15+ devices with the error:
+
+```
+java.lang.UnsatisfiedLinkError: dlopen failed:
+"libbeepingcore.so" program alignment (4096) cannot be smaller than
+system page size (16384)
+```
+
+CI guards this in two places: an inline `readelf` check in the `android`
+job (build-time) and a separate `android-smoke` job that re-validates the
+*packaged* tarball post-upload, so a release with a broken alignment
+cannot be published.
+
+---
+
 ## Reporting issues
 
 If any verification fails unexpectedly, do not run the binary. Open an issue at


### PR DESCRIPTION
## Summary

Closes the only remaining task that could be advanced from our side in
**Phase 1 — beeping-core (C++20)**: BEE-2221 ships Android NDK shared
libraries in every release of `beeping-core`, with 16 KB page-size
alignment for Android 15+ compatibility and lowercase naming so JNI's
`System.loadLibrary("beepingcore")` resolves correctly.

The remaining BEE-30 (Conan recipe + ConanCenter publish) is functionally
shipped from our side; what's left is external review by a ConanCenter
maintainer (CLA was signed today + CI re-trigger pushed). Per the global
methodology rule "no bloquear phases downstream por registries con review
humano", we ship BEE-2221 to `develop` now so Phase 8 (BEE-65) can
consume the new `.so` artifacts. The Phase 1 milestone in Linear stays
open until BEE-30's external review resolves; Phase H cleanup will land
in a separate small PR (`feat/bee-30-phase-h-badge`) when that happens.

Closes BEE-2221.

## What changed

- **`.github/workflows/release.yml`** · re-enables the `android` job
  (BEE-29 had it gated with `if: false`) and brings it up to spec:
  - NDK r26d → r27c
  - `BUILD_SHARED_LIBS=OFF → ON` (produces `.so` instead of `.a`)
  - `ANDROID_PLATFORM android-21 → android-24` (matches `beeping-android`
    `minSdkVersion=24`)
  - `CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"` — the
    Android 15+ enforcement that prompted BEE-2221 in the first place
  - `BEEPING_BUILD_CLI=OFF` (CLI doesn't apply to a shared-library target)
  - inline `readelf -W -l` build-time check that fails the job if any
    `LOAD` segment lands at align `< 0x4000`
  - new `android-smoke` job that re-extracts each just-published tarball
    and re-runs the readelf assertion + verifies shape
    (`lib/libbeepingcore.so` + `include/`) before `hashes`/`release`
    are allowed to run
- **`CMakeLists.txt`** · `if(ANDROID) → set OUTPUT_NAME "beepingcore"`,
  surgical to Android only — other platforms keep `libBeepingCore.*`
- **`docs/RELEASES.md`** · annotates the Android rows with "16 KB pages,
  minSdk 24" and adds a drop-in extract example for
  `app/src/main/jniLibs/<abi>/`
- **`docs/verifying-releases.md`** · new section 5 with the full
  `readelf -W -l` recipe + the `UnsatisfiedLinkError` message it prevents

## Test plan

- [x] `gh workflow run release.yml -f tag=v0.0.0-bee2221-test` from
      `milestone/phase-1-beeping-core` → run [25505016203](https://github.com/beeping-io/beeping-core/actions/runs/25505016203) green:
  - 3× Android NDK builds — `Detected LOAD aligns: 0x4000` for all
    three ABIs
  - 3× Android smoke (re-extract + re-readelf) — green
  - macOS, Linux x2, Linux compat smokes (9), Windows x2, WASM, SBOM —
    all green (no regression in untouched targets)
- [x] Local QA: downloaded `beeping-core-android-arm64-v8a.tar.zst`,
      verified shape (`lib/libbeepingcore.so` lowercase + 16
      `include/*.h` headers + `lib/cmake/BeepingCore/`), inspected
      readelf output from CI confirming `0x4000` alignment on all
      three LOAD segments
- [ ] End-to-end consumer validation deferred to **BEE-65** in Phase 8
      (Gradle download + cosign verify + emulator API 35 + device
      Android 14 + `LocalEncoder` JNI integration) — not blocking this
      PR per BEE-2221's Human QA Checkpoint scope
- [ ] First real release after merge will exercise the cosign /
      SBOM / SLSA path (gated to `refs/tags/`, not exercised by
      `workflow_dispatch`)