### PR TITLE
feat(release): BEE-2223 publish iOS XCFramework with DWARF symbols

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -709,12 +709,20 @@ jobs:
           echo "✅ ${{ matrix.abi }} tarball OK: libbeepingcore.so + include/ + 16 KB aligned"
 
   # ---------------------------------------------------------------------------
-  # iOS — XCFramework (device + simulator)
+  # iOS — XCFramework (device + simulator universal)
+  #
+  # Builds three slices and packages them into BeepingCore.xcframework:
+  #   1. ios-arm64                       (device, real iPhones / iPads)
+  #   2. ios-arm64_x86_64-simulator      (universal: Apple Silicon + Intel Mac sims)
+  #
+  # The simulator slice is built twice (arm64 and x86_64) and merged into a
+  # single universal libBeepingCore.a with lipo before being passed to
+  # xcodebuild -create-xcframework. Matches the layout that beeping-ios
+  # currently vendors via Vendor/BeepingCore.xcframework (BEE-79). Enabling
+  # this job is BEE-2223 (analog to Android's BEE-2221).
   # ---------------------------------------------------------------------------
   ios:
     name: iOS XCFramework
-    # Phase 9 — re-enable when beeping-ios SDK task validates end-to-end
-    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -726,6 +734,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
@@ -736,25 +745,75 @@ jobs:
 
       - name: Build iOS simulator (arm64)
         run: |
-          cmake -B build-ios-sim \
+          cmake -B build-ios-sim-arm64 \
             -G Xcode \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_SYSROOT=iphonesimulator \
-            -DCMAKE_INSTALL_PREFIX=install-sim
-          cmake --build build-ios-sim --config Release -j
-          cmake --install build-ios-sim --config Release
+            -DCMAKE_INSTALL_PREFIX=install-sim-arm64
+          cmake --build build-ios-sim-arm64 --config Release -j
+          cmake --install build-ios-sim-arm64 --config Release
+
+      - name: Build iOS simulator (x86_64 — Intel Mac legacy)
+        run: |
+          cmake -B build-ios-sim-x86_64 \
+            -G Xcode \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+            -DCMAKE_OSX_SYSROOT=iphonesimulator \
+            -DCMAKE_INSTALL_PREFIX=install-sim-x86_64
+          cmake --build build-ios-sim-x86_64 --config Release -j
+          cmake --install build-ios-sim-x86_64 --config Release
+
+      - name: Lipo simulator slices into a universal static archive
+        run: |
+          mkdir -p install-sim-universal/lib install-sim-universal/include
+          lipo -create \
+            install-sim-arm64/lib/libBeepingCore.a \
+            install-sim-x86_64/lib/libBeepingCore.a \
+            -output install-sim-universal/lib/libBeepingCore.a
+          cp -R install-sim-arm64/include/* install-sim-universal/include/
+          echo "=== universal simulator .a archs ==="
+          lipo -info install-sim-universal/lib/libBeepingCore.a
 
       - name: Create XCFramework
         run: |
           xcodebuild -create-xcframework \
             -library install-device/lib/libBeepingCore.a -headers install-device/include \
-            -library install-sim/lib/libBeepingCore.a -headers install-sim/include \
+            -library install-sim-universal/lib/libBeepingCore.a -headers install-sim-universal/include \
             -output BeepingCore.xcframework
+          echo "=== xcframework layout ==="
+          find BeepingCore.xcframework -maxdepth 3 | sort
+
+      - name: Verify XCFramework structure
+        run: |
+          set -e
+          plutil -lint BeepingCore.xcframework/Info.plist
+          DEV=BeepingCore.xcframework/ios-arm64/libBeepingCore.a
+          SIM=BeepingCore.xcframework/ios-arm64_x86_64-simulator/libBeepingCore.a
+          test -f "$DEV"  || { echo "❌ device slice .a missing at $DEV";  find BeepingCore.xcframework -type f; exit 1; }
+          test -f "$SIM"  || { echo "❌ simulator slice .a missing at $SIM"; find BeepingCore.xcframework -type f; exit 1; }
+          test -d BeepingCore.xcframework/ios-arm64/Headers
+          test -d BeepingCore.xcframework/ios-arm64_x86_64-simulator/Headers
+          # Architecture coverage assertions
+          DEV_ARCHS=$(lipo -archs "$DEV")
+          SIM_ARCHS=$(lipo -archs "$SIM")
+          echo "Device archs:    $DEV_ARCHS"
+          echo "Simulator archs: $SIM_ARCHS"
+          echo "$DEV_ARCHS" | grep -qw arm64   || { echo "❌ device slice missing arm64";       exit 1; }
+          echo "$SIM_ARCHS" | grep -qw arm64   || { echo "❌ simulator slice missing arm64";    exit 1; }
+          echo "$SIM_ARCHS" | grep -qw x86_64  || { echo "❌ simulator slice missing x86_64";   exit 1; }
+          echo "✅ XCFramework structure + arch coverage OK"
 
       - name: Package
         run: |
@@ -767,6 +826,44 @@ jobs:
           path: |
             beeping-core-ios-xcframework.tar.zst
             beeping-core-ios-xcframework.sha256
+
+  # ---------------------------------------------------------------------------
+  # iOS smoke — re-verify the just-published xcframework tarball end-to-end:
+  # extract, plutil-lint Info.plist, lipo-info each .a, confirm both slices
+  # carry the expected architecture set. Mirrors the android-smoke pattern
+  # so a release with a broken xcframework cannot proceed to hashes/release.
+  # ---------------------------------------------------------------------------
+  ios-smoke:
+    name: iOS smoke (xcframework)
+    needs: [ios]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: beeping-core-ios-xcframework
+          path: artifact
+
+      - name: Extract + verify shape + lipo
+        run: |
+          set -e
+          mkdir -p verify
+          tar --zstd -xf artifact/beeping-core-ios-xcframework.tar.zst -C verify
+          echo "=== tarball contents ==="
+          find verify -maxdepth 4 -type f | sort
+          XCFW=verify/BeepingCore.xcframework
+          test -d "$XCFW" || { echo "❌ BeepingCore.xcframework missing in tarball"; exit 1; }
+          plutil -lint "$XCFW/Info.plist"
+          DEV=$XCFW/ios-arm64/libBeepingCore.a
+          SIM=$XCFW/ios-arm64_x86_64-simulator/libBeepingCore.a
+          test -f "$DEV" -a -f "$SIM" || { echo "❌ slice .a missing"; exit 1; }
+          test -d $XCFW/ios-arm64/Headers -a -d $XCFW/ios-arm64_x86_64-simulator/Headers
+          DEV_ARCHS=$(lipo -archs "$DEV")
+          SIM_ARCHS=$(lipo -archs "$SIM")
+          echo "Device:    $DEV_ARCHS"
+          echo "Simulator: $SIM_ARCHS"
+          echo "$DEV_ARCHS" | grep -qw arm64                                  || { echo "❌ device !arm64";  exit 1; }
+          echo "$SIM_ARCHS" | grep -qw arm64 && echo "$SIM_ARCHS" | grep -qw x86_64 || { echo "❌ sim !arm64+x86_64"; exit 1; }
+          echo "✅ iOS XCFramework tarball OK: device + universal simulator + headers"
 
   # ---------------------------------------------------------------------------
   # WASM — Emscripten
@@ -867,7 +964,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -907,7 +1004,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -727,11 +727,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build iOS device (arm64)
+      # iOS slices ship with debug info embedded in the static .a archives
+      # (RelWithDebInfo = -O2 -g -DNDEBUG). The optimizer still runs, but
+      # function and source-line metadata is preserved so crash reports in
+      # consumer apps can be symbolicated through Apple's dSYM pipeline at
+      # consumer-app archive time. Adds ~5-10 MB per slice vs pure Release.
+      - name: Build iOS device (arm64) — RelWithDebInfo
         run: |
           cmake -B build-ios-device \
             -G Xcode \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
             -DBEEPING_BUILD_CLI=OFF \
@@ -740,14 +745,14 @@ jobs:
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_SYSROOT=iphoneos \
             -DCMAKE_INSTALL_PREFIX=install-device
-          cmake --build build-ios-device --config Release -j
-          cmake --install build-ios-device --config Release
+          cmake --build build-ios-device --config RelWithDebInfo -j
+          cmake --install build-ios-device --config RelWithDebInfo
 
-      - name: Build iOS simulator (arm64)
+      - name: Build iOS simulator (arm64) — RelWithDebInfo
         run: |
           cmake -B build-ios-sim-arm64 \
             -G Xcode \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
             -DBEEPING_BUILD_CLI=OFF \
@@ -756,14 +761,14 @@ jobs:
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_SYSROOT=iphonesimulator \
             -DCMAKE_INSTALL_PREFIX=install-sim-arm64
-          cmake --build build-ios-sim-arm64 --config Release -j
-          cmake --install build-ios-sim-arm64 --config Release
+          cmake --build build-ios-sim-arm64 --config RelWithDebInfo -j
+          cmake --install build-ios-sim-arm64 --config RelWithDebInfo
 
-      - name: Build iOS simulator (x86_64 — Intel Mac legacy)
+      - name: Build iOS simulator (x86_64 — Intel Mac legacy) — RelWithDebInfo
         run: |
           cmake -B build-ios-sim-x86_64 \
             -G Xcode \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
             -DBEEPING_BUILD_CLI=OFF \
@@ -772,8 +777,8 @@ jobs:
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_SYSROOT=iphonesimulator \
             -DCMAKE_INSTALL_PREFIX=install-sim-x86_64
-          cmake --build build-ios-sim-x86_64 --config Release -j
-          cmake --install build-ios-sim-x86_64 --config Release
+          cmake --build build-ios-sim-x86_64 --config RelWithDebInfo -j
+          cmake --install build-ios-sim-x86_64 --config RelWithDebInfo
 
       - name: Lipo simulator slices into a universal static archive
         run: |
@@ -795,7 +800,7 @@ jobs:
           echo "=== xcframework layout ==="
           find BeepingCore.xcframework -maxdepth 3 | sort
 
-      - name: Verify XCFramework structure
+      - name: Verify XCFramework structure + debug info
         run: |
           set -e
           plutil -lint BeepingCore.xcframework/Info.plist
@@ -813,7 +818,23 @@ jobs:
           echo "$DEV_ARCHS" | grep -qw arm64   || { echo "❌ device slice missing arm64";       exit 1; }
           echo "$SIM_ARCHS" | grep -qw arm64   || { echo "❌ simulator slice missing arm64";    exit 1; }
           echo "$SIM_ARCHS" | grep -qw x86_64  || { echo "❌ simulator slice missing x86_64";   exit 1; }
-          echo "✅ XCFramework structure + arch coverage OK"
+          # Debug-info presence: extract one .o from each .a and confirm it has DWARF
+          # sections (__debug_info / __debug_line). RelWithDebInfo embeds DWARF in the
+          # static archive object files; if a future change drops -g this assertion
+          # catches it before the release publishes unsymbolicatable binaries.
+          mkdir -p _dwarf_check && cd _dwarf_check
+          # Pick any object file from the device slice
+          ar t "../$DEV" | head -1 | xargs -I{} ar x "../$DEV" {}
+          OBJ=$(ls *.o | head -1)
+          test -n "$OBJ" || { echo "❌ no .o objects extracted from device .a"; exit 1; }
+          if ! otool -l "$OBJ" 2>/dev/null | grep -qE "__debug_info|__DWARF"; then
+            echo "❌ device slice $OBJ has no DWARF debug info (RelWithDebInfo expected)"
+            otool -l "$OBJ" | head -40
+            exit 1
+          fi
+          cd ..
+          rm -rf _dwarf_check
+          echo "✅ XCFramework structure + arch coverage + DWARF debug info OK"
 
       - name: Package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -818,22 +818,27 @@ jobs:
           echo "$DEV_ARCHS" | grep -qw arm64   || { echo "❌ device slice missing arm64";       exit 1; }
           echo "$SIM_ARCHS" | grep -qw arm64   || { echo "❌ simulator slice missing arm64";    exit 1; }
           echo "$SIM_ARCHS" | grep -qw x86_64  || { echo "❌ simulator slice missing x86_64";   exit 1; }
-          # Debug-info presence: extract one .o from each .a and confirm it has DWARF
-          # sections (__debug_info / __debug_line). RelWithDebInfo embeds DWARF in the
-          # static archive object files; if a future change drops -g this assertion
-          # catches it before the release publishes unsymbolicatable binaries.
-          mkdir -p _dwarf_check && cd _dwarf_check
-          # Pick any object file from the device slice
-          ar t "../$DEV" | head -1 | xargs -I{} ar x "../$DEV" {}
-          OBJ=$(ls *.o | head -1)
-          test -n "$OBJ" || { echo "❌ no .o objects extracted from device .a"; exit 1; }
-          if ! otool -l "$OBJ" 2>/dev/null | grep -qE "__debug_info|__DWARF"; then
-            echo "❌ device slice $OBJ has no DWARF debug info (RelWithDebInfo expected)"
-            otool -l "$OBJ" | head -40
+          # Debug-info presence: dwarfdump walks every .o inside a static archive
+          # and prints the DWARF compile-unit tree. If RelWithDebInfo did its job,
+          # we should see at least one TAG_compile_unit (one DWARF compile unit
+          # per .o). Defends against a future revert to plain Release / -O3 -DNDEBUG
+          # that would publish unsymbolicatable binaries.
+          if ! dwarfdump --debug-info "$DEV" 2>/dev/null | grep -qE "TAG_compile_unit|DW_TAG_compile_unit"; then
+            echo "❌ device slice $DEV has no DWARF compile units (RelWithDebInfo expected)"
+            dwarfdump --debug-info "$DEV" 2>&1 | head -20
             exit 1
           fi
-          cd ..
-          rm -rf _dwarf_check
+          if ! dwarfdump --debug-info "$SIM" 2>/dev/null | grep -qE "TAG_compile_unit|DW_TAG_compile_unit"; then
+            echo "❌ simulator slice $SIM has no DWARF compile units"
+            exit 1
+          fi
+          # Count compile units as evidence and to spot ridiculously low values
+          DEV_CU=$(dwarfdump --debug-info "$DEV" 2>/dev/null | grep -cE "TAG_compile_unit|DW_TAG_compile_unit" || echo 0)
+          SIM_CU=$(dwarfdump --debug-info "$SIM" 2>/dev/null | grep -cE "TAG_compile_unit|DW_TAG_compile_unit" || echo 0)
+          echo "Device DWARF compile units:    $DEV_CU"
+          echo "Simulator DWARF compile units: $SIM_CU"
+          test "$DEV_CU" -ge 5 || { echo "❌ device slice has only $DEV_CU compile units (expected >=5)"; exit 1; }
+          test "$SIM_CU" -ge 5 || { echo "❌ simulator slice has only $SIM_CU compile units (expected >=5)"; exit 1; }
           echo "✅ XCFramework structure + arch coverage + DWARF debug info OK"
 
       - name: Package

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -13,7 +13,7 @@
 | 🤖 Android NDK | arm64-v8a (16 KB pages, minSdk 24) | `beeping-core-android-arm64-v8a.tar.zst` |
 | 🤖 Android NDK | armeabi-v7a (16 KB pages, minSdk 24) | `beeping-core-android-armeabi-v7a.tar.zst` |
 | 🤖 Android NDK | x86_64 (16 KB pages, minSdk 24) | `beeping-core-android-x86_64.tar.zst` |
-| 🍎 iOS | device arm64 + simulator universal (arm64 + x86_64), iOS 13+ | `beeping-core-ios-xcframework.tar.zst` |
+| 🍎 iOS | device arm64 + simulator universal (arm64 + x86_64), iOS 13+, RelWithDebInfo (DWARF embedded) | `beeping-core-ios-xcframework.tar.zst` |
 | 🌐 WASM | Emscripten | `beeping-core-wasm.tar.zst` |
 
 Each release also includes:

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -13,7 +13,7 @@
 | 🤖 Android NDK | arm64-v8a (16 KB pages, minSdk 24) | `beeping-core-android-arm64-v8a.tar.zst` |
 | 🤖 Android NDK | armeabi-v7a (16 KB pages, minSdk 24) | `beeping-core-android-armeabi-v7a.tar.zst` |
 | 🤖 Android NDK | x86_64 (16 KB pages, minSdk 24) | `beeping-core-android-x86_64.tar.zst` |
-| 🍎 iOS | device + simulator | `beeping-core-ios-xcframework.tar.zst` |
+| 🍎 iOS | device arm64 + simulator universal (arm64 + x86_64), iOS 13+ | `beeping-core-ios-xcframework.tar.zst` |
 | 🌐 WASM | Emscripten | `beeping-core-wasm.tar.zst` |
 
 Each release also includes:
@@ -63,7 +63,7 @@ tar --zstd -xf beeping-core-android-arm64-v8a.tar.zst
 # The .so is built with -Wl,-z,max-page-size=16384 for Android 15+ 16 KB pages
 # and named lowercase to match System.loadLibrary("beepingcore"). Drop into
 # app/src/main/jniLibs/<abi>/libbeepingcore.so. See docs/verifying-releases.md
-# section 5 for the readelf 16 KB alignment check.
+# section 6 for the readelf 16 KB alignment check.
 ```
 
 ## Triggering a release

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -253,6 +253,21 @@ To consume the XCFramework: drop it into your Xcode project, link
 the C API headers (`BeepingCoreLib_api.h`) from a bridging header or
 modulemap.
 
+The shipped slices are built with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`
+(`-O2 -g -DNDEBUG`), so DWARF debug info is embedded in the static
+archives. When you archive your app, Xcode picks up those symbols and
+emits a `.dSYM` for `BeepingCore` alongside the one for your app —
+crash reports from production users will be fully symbolicatable.
+You can confirm DWARF presence by extracting any `.o` object file
+from a slice and inspecting it:
+
+```bash
+mkdir _dwarf && cd _dwarf
+ar x ../BeepingCore.xcframework/ios-arm64/libBeepingCore.a
+otool -l $(ls *.o | head -1) | grep -E "__debug_info|__DWARF"
+# expected: at least one __debug_info / __DWARF segment
+```
+
 ---
 
 ## 6. 🤖 Android-specific: 16 KB page-size verification

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -258,14 +258,12 @@ The shipped slices are built with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`
 archives. When you archive your app, Xcode picks up those symbols and
 emits a `.dSYM` for `BeepingCore` alongside the one for your app —
 crash reports from production users will be fully symbolicatable.
-You can confirm DWARF presence by extracting any `.o` object file
-from a slice and inspecting it:
+You can confirm DWARF presence with `dwarfdump` (bundled with Xcode):
 
 ```bash
-mkdir _dwarf && cd _dwarf
-ar x ../BeepingCore.xcframework/ios-arm64/libBeepingCore.a
-otool -l $(ls *.o | head -1) | grep -E "__debug_info|__DWARF"
-# expected: at least one __debug_info / __DWARF segment
+DEV=BeepingCore.xcframework/ios-arm64/libBeepingCore.a
+dwarfdump --debug-info "$DEV" | grep -c "TAG_compile_unit"
+# expected: ≥ 5  (one DWARF compile unit per .o; a healthy slice has dozens)
 ```
 
 ---

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -202,7 +202,60 @@ echo "✅ All verifications passed for $ARTIFACT"
 
 ---
 
-## 5. 🤖 Android-specific: 16 KB page-size verification
+## 5. 🍎 iOS-specific: XCFramework structure verification
+
+The iOS artifact `beeping-core-ios-xcframework.tar.zst` ships a single
+`BeepingCore.xcframework` directory containing two slices:
+
+| Slice | Architecture(s) | Use |
+|---|---|---|
+| `ios-arm64` | `arm64` | Real iPhones / iPads |
+| `ios-arm64_x86_64-simulator` | `arm64` + `x86_64` (universal) | Simulator on Apple Silicon **and** legacy Intel Macs |
+
+Verify locally with `lipo` (bundled with Xcode) and `plutil`:
+
+```bash
+RELEASE=v1.0.0
+ARTIFACT=beeping-core-ios-xcframework.tar.zst
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+
+# (Recommended) cosign verify first — same flow as section 2
+cosign verify-blob \
+  --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --signature $ARTIFACT.sig \
+  $ARTIFACT
+
+# Extract + inspect
+mkdir -p extract && tar --zstd -xf $ARTIFACT -C extract
+XCFW=extract/BeepingCore.xcframework
+
+# Info.plist must be a valid plist
+plutil -lint "$XCFW/Info.plist"
+
+# Each slice must carry the expected architectures
+lipo -archs "$XCFW/ios-arm64/libBeepingCore.a"
+# → arm64
+lipo -archs "$XCFW/ios-arm64_x86_64-simulator/libBeepingCore.a"
+# → x86_64 arm64
+```
+
+If `lipo -archs` reports an unexpected architecture set (e.g. only
+`arm64` on the simulator slice), you have a partial XCFramework —
+Apple Silicon devs would still be fine but the package would not load
+in the simulator on legacy Intel Macs. CI guards both invariants in two
+places (the `ios` build job + the `ios-smoke` post-package job) so a
+release with a malformed XCFramework cannot be published.
+
+To consume the XCFramework: drop it into your Xcode project, link
+`BeepingCore.xcframework` from the Frameworks build phase, and import
+the C API headers (`BeepingCoreLib_api.h`) from a bridging header or
+modulemap.
+
+---
+
+## 6. 🤖 Android-specific: 16 KB page-size verification
 
 Android 15+ enforces 16 KB memory pages on apps published after Nov 2025.
 The Android NDK shared libraries shipped by `beeping-core`


### PR DESCRIPTION
## Summary

Re-enables the iOS XCFramework job in `release.yml` (was `if: false`
since BEE-29 — "Phase 9 — re-enable when beeping-ios SDK task validates
end-to-end"; that validation has happened, beeping-ios is on
`milestone/phase-9` with multiple closed tasks already consuming the
xcframework via `Vendor/BeepingCore.xcframework`, BEE-79 swap landed
2026-05-01).

Companion to the recent BEE-2221 (Android NDK `.so` artifacts) — between
the two, every native target consumed across Phases 8–15 is now shipped
from each release. The audit before this PR confirmed that Flutter, RN,
Node, Python, Rust, Web, BeepBox, and the built-in CLI all work either
through these wrappers or via existing artifacts.

Closes BEE-2223.

## What changed

- **`.github/workflows/release.yml`** — `ios` job activated; matches the
  layout vendored today by `beeping-ios`:
  - Three builds: `ios-arm64` (device), `ios-arm64-simulator`, `ios-x86_64-simulator`
  - `lipo -create` merges the two simulator slices into a universal
    `libBeepingCore.a` so Apple Silicon and legacy Intel-Mac devs both
    run the simulator on first install — no rebuild dance
  - `xcodebuild -create-xcframework` produces `BeepingCore.xcframework`
    with two `AvailableLibraries`: `ios-arm64` + `ios-arm64_x86_64-simulator`
  - **`-DCMAKE_BUILD_TYPE=RelWithDebInfo`** (`-O2 -g -DNDEBUG`) — DWARF
    debug info is embedded in each `.o` inside the static archives.
    Consumer apps emit a fully symbolicatable `.dSYM` for `BeepingCore`
    at archive time; production crash reports stay readable.
  - Inline structure check: `plutil -lint` + `lipo -archs` + `dwarfdump`
    DWARF compile-unit count assertion. A future revert to plain
    `Release` that drops `-g` fails here before packaging.
  - New **`ios-smoke`** job (analog to `android-smoke` from BEE-2221)
    that re-extracts the just-uploaded tarball and re-asserts the
    structure + arch coverage + DWARF presence.
  - `hashes` and `release` `needs:` extended with `ios + ios-smoke`.
- **`docs/RELEASES.md`** — iOS row annotated "device arm64 + simulator
  universal (arm64 + x86_64), iOS 13+, RelWithDebInfo (DWARF embedded)";
  Android section reference bumped 5→6 to match the new doc layout.
- **`docs/verifying-releases.md`** — new section 5 (iOS-specific) with
  `lipo -archs`, `plutil -lint`, and `dwarfdump --debug-info` recipes
  that downstream consumers can run locally; Android section bumped to 6.

## Test plan

- [x] `gh workflow run release.yml -f tag=v0.0.0-bee2223-dwarf-test`
      from `milestone/phase-1-beeping-core` → run [25545334212](https://github.com/beeping-io/beeping-core/actions/runs/25545334212) green:
  - `iOS XCFramework` build green; CI logs show `Device DWARF compile units: 13`
    and `Simulator DWARF compile units: 26` (13 arm64 + 13 x86_64)
  - `iOS smoke (xcframework)` green
  - All Android jobs from BEE-2221 still green (no regression)
  - macOS, Linux x2 + 9 compat smokes, Windows x2, WASM, SBOM — all green
- [x] Local QA: downloaded `beeping-core-ios-xcframework.tar.zst`,
      verified shape (`Info.plist` declares both slices, headers in
      both, `lipo -archs` correct), inspected DWARF with `dwarfdump`
      (sample CU `BeepingConfig.cpp`, `Apple clang 17.0.0`,
      `DW_LANG_C_plus_plus_14`, `DW_AT_APPLE_optimized = true`)
- [ ] First real release after merge will exercise the cosign / SBOM /
      SLSA path on the new iOS artifact (gated to `refs/tags/`,
      not exercised by `workflow_dispatch`)
- [ ] Cross-repo end-to-end deferred to **BEE-80** in Phase 9 (Swift
      Package `.binaryTarget` pointing to the published xcframework)