### PR TITLE
release: develop → main · 12 commits across 6 BEE tasks (cuts v0.7.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -709,52 +709,137 @@ jobs:
           echo "✅ ${{ matrix.abi }} tarball OK: libbeepingcore.so + include/ + 16 KB aligned"
 
   # ---------------------------------------------------------------------------
-  # iOS — XCFramework (device + simulator)
+  # iOS — XCFramework (device + simulator universal)
+  #
+  # Builds three slices and packages them into BeepingCore.xcframework:
+  #   1. ios-arm64                       (device, real iPhones / iPads)
+  #   2. ios-arm64_x86_64-simulator      (universal: Apple Silicon + Intel Mac sims)
+  #
+  # The simulator slice is built twice (arm64 and x86_64) and merged into a
+  # single universal libBeepingCore.a with lipo before being passed to
+  # xcodebuild -create-xcframework. Matches the layout that beeping-ios
+  # currently vendors via Vendor/BeepingCore.xcframework (BEE-79). Enabling
+  # this job is BEE-2223 (analog to Android's BEE-2221).
   # ---------------------------------------------------------------------------
   ios:
     name: iOS XCFramework
-    # Phase 9 — re-enable when beeping-ios SDK task validates end-to-end
-    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build iOS device (arm64)
+      # iOS slices ship with debug info embedded in the static .a archives
+      # (RelWithDebInfo = -O2 -g -DNDEBUG). The optimizer still runs, but
+      # function and source-line metadata is preserved so crash reports in
+      # consumer apps can be symbolicated through Apple's dSYM pipeline at
+      # consumer-app archive time. Adds ~5-10 MB per slice vs pure Release.
+      - name: Build iOS device (arm64) — RelWithDebInfo
         run: |
           cmake -B build-ios-device \
             -G Xcode \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_SYSROOT=iphoneos \
             -DCMAKE_INSTALL_PREFIX=install-device
-          cmake --build build-ios-device --config Release -j
-          cmake --install build-ios-device --config Release
+          cmake --build build-ios-device --config RelWithDebInfo -j
+          cmake --install build-ios-device --config RelWithDebInfo
 
-      - name: Build iOS simulator (arm64)
+      - name: Build iOS simulator (arm64) — RelWithDebInfo
         run: |
-          cmake -B build-ios-sim \
+          cmake -B build-ios-sim-arm64 \
             -G Xcode \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_SYSROOT=iphonesimulator \
-            -DCMAKE_INSTALL_PREFIX=install-sim
-          cmake --build build-ios-sim --config Release -j
-          cmake --install build-ios-sim --config Release
+            -DCMAKE_INSTALL_PREFIX=install-sim-arm64
+          cmake --build build-ios-sim-arm64 --config RelWithDebInfo -j
+          cmake --install build-ios-sim-arm64 --config RelWithDebInfo
+
+      - name: Build iOS simulator (x86_64 — Intel Mac legacy) — RelWithDebInfo
+        run: |
+          cmake -B build-ios-sim-x86_64 \
+            -G Xcode \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+            -DCMAKE_OSX_SYSROOT=iphonesimulator \
+            -DCMAKE_INSTALL_PREFIX=install-sim-x86_64
+          cmake --build build-ios-sim-x86_64 --config RelWithDebInfo -j
+          cmake --install build-ios-sim-x86_64 --config RelWithDebInfo
+
+      - name: Lipo simulator slices into a universal static archive
+        run: |
+          mkdir -p install-sim-universal/lib install-sim-universal/include
+          lipo -create \
+            install-sim-arm64/lib/libBeepingCore.a \
+            install-sim-x86_64/lib/libBeepingCore.a \
+            -output install-sim-universal/lib/libBeepingCore.a
+          cp -R install-sim-arm64/include/* install-sim-universal/include/
+          echo "=== universal simulator .a archs ==="
+          lipo -info install-sim-universal/lib/libBeepingCore.a
 
       - name: Create XCFramework
         run: |
           xcodebuild -create-xcframework \
             -library install-device/lib/libBeepingCore.a -headers install-device/include \
-            -library install-sim/lib/libBeepingCore.a -headers install-sim/include \
+            -library install-sim-universal/lib/libBeepingCore.a -headers install-sim-universal/include \
             -output BeepingCore.xcframework
+          echo "=== xcframework layout ==="
+          find BeepingCore.xcframework -maxdepth 3 | sort
+
+      - name: Verify XCFramework structure + debug info
+        run: |
+          set -e
+          plutil -lint BeepingCore.xcframework/Info.plist
+          DEV=BeepingCore.xcframework/ios-arm64/libBeepingCore.a
+          SIM=BeepingCore.xcframework/ios-arm64_x86_64-simulator/libBeepingCore.a
+          test -f "$DEV"  || { echo "❌ device slice .a missing at $DEV";  find BeepingCore.xcframework -type f; exit 1; }
+          test -f "$SIM"  || { echo "❌ simulator slice .a missing at $SIM"; find BeepingCore.xcframework -type f; exit 1; }
+          test -d BeepingCore.xcframework/ios-arm64/Headers
+          test -d BeepingCore.xcframework/ios-arm64_x86_64-simulator/Headers
+          # Architecture coverage assertions
+          DEV_ARCHS=$(lipo -archs "$DEV")
+          SIM_ARCHS=$(lipo -archs "$SIM")
+          echo "Device archs:    $DEV_ARCHS"
+          echo "Simulator archs: $SIM_ARCHS"
+          echo "$DEV_ARCHS" | grep -qw arm64   || { echo "❌ device slice missing arm64";       exit 1; }
+          echo "$SIM_ARCHS" | grep -qw arm64   || { echo "❌ simulator slice missing arm64";    exit 1; }
+          echo "$SIM_ARCHS" | grep -qw x86_64  || { echo "❌ simulator slice missing x86_64";   exit 1; }
+          # Debug-info presence: dwarfdump walks every .o inside a static archive
+          # and prints the DWARF compile-unit tree. If RelWithDebInfo did its job,
+          # we should see at least one TAG_compile_unit (one DWARF compile unit
+          # per .o). Defends against a future revert to plain Release / -O3 -DNDEBUG
+          # that would publish unsymbolicatable binaries.
+          if ! dwarfdump --debug-info "$DEV" 2>/dev/null | grep -qE "TAG_compile_unit|DW_TAG_compile_unit"; then
+            echo "❌ device slice $DEV has no DWARF compile units (RelWithDebInfo expected)"
+            dwarfdump --debug-info "$DEV" 2>&1 | head -20
+            exit 1
+          fi
+          if ! dwarfdump --debug-info "$SIM" 2>/dev/null | grep -qE "TAG_compile_unit|DW_TAG_compile_unit"; then
+            echo "❌ simulator slice $SIM has no DWARF compile units"
+            exit 1
+          fi
+          # Count compile units as evidence and to spot ridiculously low values
+          DEV_CU=$(dwarfdump --debug-info "$DEV" 2>/dev/null | grep -cE "TAG_compile_unit|DW_TAG_compile_unit" || echo 0)
+          SIM_CU=$(dwarfdump --debug-info "$SIM" 2>/dev/null | grep -cE "TAG_compile_unit|DW_TAG_compile_unit" || echo 0)
+          echo "Device DWARF compile units:    $DEV_CU"
+          echo "Simulator DWARF compile units: $SIM_CU"
+          test "$DEV_CU" -ge 5 || { echo "❌ device slice has only $DEV_CU compile units (expected >=5)"; exit 1; }
+          test "$SIM_CU" -ge 5 || { echo "❌ simulator slice has only $SIM_CU compile units (expected >=5)"; exit 1; }
+          echo "✅ XCFramework structure + arch coverage + DWARF debug info OK"
 
       - name: Package
         run: |
@@ -767,6 +852,44 @@ jobs:
           path: |
             beeping-core-ios-xcframework.tar.zst
             beeping-core-ios-xcframework.sha256
+
+  # ---------------------------------------------------------------------------
+  # iOS smoke — re-verify the just-published xcframework tarball end-to-end:
+  # extract, plutil-lint Info.plist, lipo-info each .a, confirm both slices
+  # carry the expected architecture set. Mirrors the android-smoke pattern
+  # so a release with a broken xcframework cannot proceed to hashes/release.
+  # ---------------------------------------------------------------------------
+  ios-smoke:
+    name: iOS smoke (xcframework)
+    needs: [ios]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: beeping-core-ios-xcframework
+          path: artifact
+
+      - name: Extract + verify shape + lipo
+        run: |
+          set -e
+          mkdir -p verify
+          tar --zstd -xf artifact/beeping-core-ios-xcframework.tar.zst -C verify
+          echo "=== tarball contents ==="
+          find verify -maxdepth 4 -type f | sort
+          XCFW=verify/BeepingCore.xcframework
+          test -d "$XCFW" || { echo "❌ BeepingCore.xcframework missing in tarball"; exit 1; }
+          plutil -lint "$XCFW/Info.plist"
+          DEV=$XCFW/ios-arm64/libBeepingCore.a
+          SIM=$XCFW/ios-arm64_x86_64-simulator/libBeepingCore.a
+          test -f "$DEV" -a -f "$SIM" || { echo "❌ slice .a missing"; exit 1; }
+          test -d $XCFW/ios-arm64/Headers -a -d $XCFW/ios-arm64_x86_64-simulator/Headers
+          DEV_ARCHS=$(lipo -archs "$DEV")
+          SIM_ARCHS=$(lipo -archs "$SIM")
+          echo "Device:    $DEV_ARCHS"
+          echo "Simulator: $SIM_ARCHS"
+          echo "$DEV_ARCHS" | grep -qw arm64                                  || { echo "❌ device !arm64";  exit 1; }
+          echo "$SIM_ARCHS" | grep -qw arm64 && echo "$SIM_ARCHS" | grep -qw x86_64 || { echo "❌ sim !arm64+x86_64"; exit 1; }
+          echo "✅ iOS XCFramework tarball OK: device + universal simulator + headers"
 
   # ---------------------------------------------------------------------------
   # WASM — Emscripten
@@ -867,7 +990,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -907,7 +1030,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,12 +544,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Arch Linux is x86_64-only upstream (Arch Linux ARM is a separate
+        # project with a different image) — omitted from this matrix. The
+        # four distros below cover every realistic Pi/arm64 deployment.
         image:
           - ubuntu:22.04
           - ubuntu:24.04
           - debian:12
           - fedora:41
-          - archlinux:latest
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,13 +473,15 @@ jobs:
             "
 
   # ---------------------------------------------------------------------------
-  # Linux — arm64 (cross-compile)
+  # Linux — arm64 (native GitHub-hosted ARM runner)
+  # ubuntu-22.04-arm = glibc 2.35 (matches amd64 baseline). Forward-compatible
+  # with Raspberry Pi OS bookworm (glibc 2.36), Ubuntu 22.04+/24.04+ arm64,
+  # Debian 12+ arm64, Fedora 41+ aarch64. Static-libstdc++/libgcc eliminates
+  # the libstdc++ runtime dependency — same trick as linux-amd64 (BEE-1729).
   # ---------------------------------------------------------------------------
   linux-arm64:
     name: Linux arm64
-    # BEE-1696 — re-enable when Linux ARM64 / Raspberry Pi validated E2E
-    if: false
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -492,13 +494,20 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
-            -DCMAKE_INSTALL_PREFIX=install
+            -DBEEPING_BUILD_CLI=ON \
+            -DCMAKE_INSTALL_PREFIX=install \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
 
       - name: Build
         run: cmake --build build --config Release -j
 
       - name: Install
         run: cmake --install build
+
+      - name: Smoke-test CLI
+        run: |
+          install/bin/beeping-core --help
+          install/bin/beeping-core --version
 
       - name: Package
         run: |
@@ -507,11 +516,62 @@ jobs:
           cd ..
           sha256sum beeping-core-linux-arm64.tar.zst > beeping-core-linux-arm64.sha256
 
+      - name: Verify CLI in tarball
+        run: |
+          mkdir verify
+          tar --zstd -xf beeping-core-linux-arm64.tar.zst -C verify
+          test -x verify/bin/beeping-core || { echo "❌ CLI binary missing in packaged tarball"; exit 1; }
+          verify/bin/beeping-core --help
+
       - uses: actions/upload-artifact@v4
         with:
           name: beeping-core-linux-arm64
           path: |
             beeping-core-linux-arm64.tar.zst
+            beeping-core-linux-arm64.sha256
+
+  # ---------------------------------------------------------------------------
+  # Linux arm64 compat smoke matrix — mirrors linux-compat-smoke but pulls
+  # arm64 variants of each distro from the native ARM runner. Covers the
+  # Raspberry Pi OS bookworm baseline (== debian:12 arm64) plus the same
+  # distro set the amd64 build validates, so the arm64 binary ships with
+  # proven cross-distro portability.
+  # ---------------------------------------------------------------------------
+  linux-arm64-compat-smoke:
+    name: Linux arm64 compat (${{ matrix.image }})
+    needs: [linux-arm64]
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - debian:12
+          - fedora:41
+          - archlinux:latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: beeping-core-linux-arm64
+          path: artifact
+
+      - name: Smoke test arm64 binary in ${{ matrix.image }}
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/artifact:/release:ro" \
+            ${{ matrix.image }} \
+            sh -c "
+              set -e
+              command -v zstd >/dev/null 2>&1 || \
+                (command -v apt-get >/dev/null 2>&1 && apt-get update -qq && apt-get install -y -qq zstd) || \
+                (command -v dnf >/dev/null 2>&1 && dnf install -y -q zstd) || \
+                (command -v pacman >/dev/null 2>&1 && pacman -Sy --noconfirm zstd)
+              tar --zstd -xf /release/beeping-core-linux-arm64.tar.zst -C /opt
+              /opt/bin/beeping-core --help
+              /opt/bin/beeping-core --version
+              echo '✅ ${{ matrix.image }} arm64 OK'
+            "
             beeping-core-linux-arm64.sha256
 
   # ---------------------------------------------------------------------------
@@ -728,7 +788,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -768,7 +828,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,14 +151,35 @@ jobs:
             exit 1
           }
           Write-Host "✅ Binary present at $exePath"
-          # dumpbin /dependents should NOT list VCRUNTIME140.dll for static build
-          $deps = & dumpbin /dependents "$exePath" 2>&1
-          Write-Host "Dependencies of beeping-core.exe:"
-          Write-Host $deps
-          if ($deps -match "VCRUNTIME\d+\.dll|MSVCP\d+\.dll") {
-            Write-Warning "⚠️ Binary depends on VC++ redistributable — expected static CRT. Output above."
+
+          # Static-CRT diagnostic: dumpbin lives inside the MSVC dev shell,
+          # so try to locate it via vswhere and fall back to a warning if
+          # unavailable. The build flags already force static CRT; this is
+          # just belt-and-suspenders.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $dumpbin = $null
+          if (Test-Path -LiteralPath $vswhere) {
+            $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+            if ($vsPath) {
+              $candidate = Get-ChildItem -Path "$vsPath\VC\Tools\MSVC" -Filter "dumpbin.exe" -Recurse -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match "Hostx64\\x64\\dumpbin.exe$" } |
+                Select-Object -First 1
+              if ($candidate) { $dumpbin = $candidate.FullName }
+            }
+          }
+
+          if ($dumpbin) {
+            Write-Host "Using dumpbin: $dumpbin"
+            $deps = & $dumpbin /dependents "$exePath" 2>&1
+            Write-Host "Dependencies of beeping-core.exe:"
+            Write-Host $deps
+            if ($deps -match "VCRUNTIME\d+\.dll|MSVCP\d+\.dll") {
+              Write-Warning "⚠️ Binary depends on VC++ redistributable — expected static CRT."
+            } else {
+              Write-Host "✅ Static CRT confirmed (no VCRUNTIME/MSVCP dynamic deps)"
+            }
           } else {
-            Write-Host "✅ Static CRT confirmed (no VCRUNTIME/MSVCP dynamic deps)"
+            Write-Warning "dumpbin not found on PATH or via vswhere — skipping static-CRT dependents check (build flags already enforce /MT)."
           }
         shell: pwsh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -631,17 +631,24 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # WASM — Emscripten
+  # Builds an ES-module `beeping-core.mjs` + `beeping-core.wasm` that
+  # decodes WAVs directly in browsers and Node via the existing C ABI
+  # (BeepingCoreLib_api.h) exposed through cwrap/ccall. A Node.js smoke
+  # test (decode two known-good WAVs against expected payload) gates
+  # the job before it publishes the artifact.
   # ---------------------------------------------------------------------------
   wasm:
     name: WASM (Emscripten)
-    # BEE-1731 — re-enable when WASM browser E2E QA validated
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y zstd
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
@@ -655,18 +662,31 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_INSTALL_PREFIX=install
 
       - name: Build
         run: cmake --build build --config Release -j
 
       - name: Install
-        run: cmake --install build
+        run: |
+          cmake --install build
+          ls -la install/wasm
+
+      - name: Node smoke test (dev + prod round-trip WAVs)
+        run: |
+          cd install/wasm
+          curl -sSLo test-dev.wav  https://storage.googleapis.com/beeping-platform-dev-qa/bee-1730/test-win-dev.wav
+          curl -sSLo test-prod.wav https://storage.googleapis.com/beeping-platform-dev-qa/bee-1730/test-win-prod.wav
+          file test-dev.wav test-prod.wav
+          node smoke-test.mjs test-dev.wav  h3l7m0000
+          node smoke-test.mjs test-prod.wav h3l7m0000
+          rm test-dev.wav test-prod.wav
 
       - name: Package
         run: |
           cd install
-          tar --zstd -cf ../beeping-core-wasm.tar.zst .
+          tar --zstd -cf ../beeping-core-wasm.tar.zst wasm/
           cd ..
           sha256sum beeping-core-wasm.tar.zst > beeping-core-wasm.sha256
 
@@ -708,7 +728,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -748,7 +768,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -629,7 +629,8 @@ jobs:
       - name: Sign binaries (cosign keyless)
         run: |
           cd artifacts
-          for f in *.tar.zst; do
+          for f in *.tar.zst *.zip; do
+            [ -f "$f" ] || continue
             cosign sign-blob --yes --output-signature "$f.sig" "$f"
           done
 
@@ -648,6 +649,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/*.tar.zst
+            artifacts/*.zip
             artifacts/*.sig
             artifacts/beeping-core-sbom.cdx.json
             artifacts/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,11 +122,12 @@ jobs:
 
       - name: Configure
         run: |
+          $installDir = Join-Path $env:GITHUB_WORKSPACE "install"
           cmake --preset conan-default `
             -DBEEPING_BUILD_CLI=ON `
             -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
             -DBUILD_TESTING=OFF `
-            -DCMAKE_INSTALL_PREFIX=install
+            "-DCMAKE_INSTALL_PREFIX=$installDir"
         shell: pwsh
 
       - name: Build
@@ -134,17 +135,24 @@ jobs:
         shell: pwsh
 
       - name: Install
-        run: cmake --install build --config Release --prefix install
+        run: |
+          $installDir = Join-Path $env:GITHUB_WORKSPACE "install"
+          cmake --install build --config Release --prefix "$installDir"
+          Write-Host "Install tree:"
+          Get-ChildItem -Recurse "$installDir" | Select-Object FullName, Length
         shell: pwsh
 
       - name: Verify CLI binary exists + static CRT
         run: |
-          if (-not (Test-Path install\bin\beeping-core.exe)) {
-            Write-Error "❌ CLI binary missing at install\bin\beeping-core.exe"
+          $exePath = Join-Path $env:GITHUB_WORKSPACE "install\bin\beeping-core.exe"
+          Write-Host "Checking: $exePath"
+          if (-not (Test-Path -LiteralPath $exePath)) {
+            Write-Error "❌ CLI binary missing at $exePath"
             exit 1
           }
+          Write-Host "✅ Binary present at $exePath"
           # dumpbin /dependents should NOT list VCRUNTIME140.dll for static build
-          $deps = & dumpbin /dependents install\bin\beeping-core.exe 2>&1
+          $deps = & dumpbin /dependents "$exePath" 2>&1
           Write-Host "Dependencies of beeping-core.exe:"
           Write-Host $deps
           if ($deps -match "VCRUNTIME\d+\.dll|MSVCP\d+\.dll") {
@@ -156,25 +164,32 @@ jobs:
 
       - name: Smoke-test CLI
         run: |
-          install\bin\beeping-core.exe --help
-          install\bin\beeping-core.exe --version
+          $exePath = Join-Path $env:GITHUB_WORKSPACE "install\bin\beeping-core.exe"
+          & "$exePath" --help
+          & "$exePath" --version
         shell: pwsh
 
       - name: Package (zip)
         run: |
-          Compress-Archive -Path install\bin,install\include,install\lib -DestinationPath beeping-core-windows-x64.zip
-          $hash = (Get-FileHash beeping-core-windows-x64.zip -Algorithm SHA256).Hash.ToLower()
-          "$hash  beeping-core-windows-x64.zip" | Out-File -FilePath beeping-core-windows-x64.sha256 -Encoding ascii
+          $installDir = Join-Path $env:GITHUB_WORKSPACE "install"
+          $zipPath    = Join-Path $env:GITHUB_WORKSPACE "beeping-core-windows-x64.zip"
+          $shaPath    = Join-Path $env:GITHUB_WORKSPACE "beeping-core-windows-x64.sha256"
+          Compress-Archive -Path (Join-Path $installDir "bin"), (Join-Path $installDir "include"), (Join-Path $installDir "lib") -DestinationPath "$zipPath"
+          $hash = (Get-FileHash "$zipPath" -Algorithm SHA256).Hash.ToLower()
+          "$hash  beeping-core-windows-x64.zip" | Out-File -FilePath "$shaPath" -Encoding ascii
         shell: pwsh
 
       - name: Verify CLI in zip
         run: |
-          Expand-Archive -Path beeping-core-windows-x64.zip -DestinationPath verify
-          if (-not (Test-Path verify\bin\beeping-core.exe)) {
-            Write-Error "❌ CLI binary missing in packaged zip"
+          $zipPath    = Join-Path $env:GITHUB_WORKSPACE "beeping-core-windows-x64.zip"
+          $verifyDir  = Join-Path $env:GITHUB_WORKSPACE "verify"
+          Expand-Archive -Path "$zipPath" -DestinationPath "$verifyDir"
+          $verifyExe = Join-Path $verifyDir "bin\beeping-core.exe"
+          if (-not (Test-Path -LiteralPath $verifyExe)) {
+            Write-Error "❌ CLI binary missing in packaged zip at $verifyExe"
             exit 1
           }
-          verify\bin\beeping-core.exe --help
+          & "$verifyExe" --help
         shell: pwsh
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,112 @@ jobs:
             beeping-core-macos-universal.sha256
 
   # ---------------------------------------------------------------------------
+  # Windows x64 — MSVC + Conan + static CRT (/MT) for zero-dependency portability
+  # Binary runs on Windows 10 1809+ and Windows 11 without VC++ redistributable.
+  # ---------------------------------------------------------------------------
+  windows-x64:
+    name: Windows x64
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Conan 2.x
+        run: |
+          pip install --upgrade pip
+          pip install "conan>=2.0,<3.0"
+          conan --version
+        shell: pwsh
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-windows-x64-release-${{ hashFiles('conan.lock') }}
+          restore-keys: |
+            conan-windows-x64-release-
+
+      - name: Install Conan deps (Release, static MSVC runtime)
+        run: |
+          conan profile detect --force
+          conan install . `
+            --build=missing `
+            --lockfile=conan.lock `
+            -pr:h=./profiles/windows-x64 `
+            -pr:b=./profiles/windows-x64 `
+            -s build_type=Release `
+            -s compiler.runtime=static
+        shell: pwsh
+
+      - name: Configure
+        run: |
+          cmake --preset conan-default `
+            -DBEEPING_BUILD_CLI=ON `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+            -DBUILD_TESTING=OFF `
+            -DCMAKE_INSTALL_PREFIX=install
+        shell: pwsh
+
+      - name: Build
+        run: cmake --build --preset conan-release --config Release
+        shell: pwsh
+
+      - name: Install
+        run: cmake --install build\Release --config Release --prefix install
+        shell: pwsh
+
+      - name: Verify CLI binary exists + static CRT
+        run: |
+          if (-not (Test-Path install\bin\beeping-core.exe)) {
+            Write-Error "❌ CLI binary missing at install\bin\beeping-core.exe"
+            exit 1
+          }
+          # dumpbin /dependents should NOT list VCRUNTIME140.dll for static build
+          $deps = & dumpbin /dependents install\bin\beeping-core.exe 2>&1
+          Write-Host "Dependencies of beeping-core.exe:"
+          Write-Host $deps
+          if ($deps -match "VCRUNTIME\d+\.dll|MSVCP\d+\.dll") {
+            Write-Warning "⚠️ Binary depends on VC++ redistributable — expected static CRT. Output above."
+          } else {
+            Write-Host "✅ Static CRT confirmed (no VCRUNTIME/MSVCP dynamic deps)"
+          }
+        shell: pwsh
+
+      - name: Smoke-test CLI
+        run: |
+          install\bin\beeping-core.exe --help
+          install\bin\beeping-core.exe --version
+        shell: pwsh
+
+      - name: Package (zip)
+        run: |
+          Compress-Archive -Path install\bin,install\include,install\lib -DestinationPath beeping-core-windows-x64.zip
+          $hash = (Get-FileHash beeping-core-windows-x64.zip -Algorithm SHA256).Hash.ToLower()
+          "$hash  beeping-core-windows-x64.zip" | Out-File -FilePath beeping-core-windows-x64.sha256 -Encoding ascii
+        shell: pwsh
+
+      - name: Verify CLI in zip
+        run: |
+          Expand-Archive -Path beeping-core-windows-x64.zip -DestinationPath verify
+          if (-not (Test-Path verify\bin\beeping-core.exe)) {
+            Write-Error "❌ CLI binary missing in packaged zip"
+            exit 1
+          }
+          verify\bin\beeping-core.exe --help
+        shell: pwsh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: beeping-core-windows-x64
+          path: |
+            beeping-core-windows-x64.zip
+            beeping-core-windows-x64.sha256
+
+  # ---------------------------------------------------------------------------
   # Linux — amd64
   # ---------------------------------------------------------------------------
   linux-amd64:
@@ -422,7 +528,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -462,7 +568,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
         shell: pwsh
 
       - name: Install
-        run: cmake --install build\Release --config Release --prefix install
+        run: cmake --install build --config Release --prefix install
         shell: pwsh
 
       - name: Verify CLI binary exists + static CRT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -577,11 +577,17 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Android NDK — arm64-v8a, armeabi-v7a, x86_64
+  #
+  # Builds shared `libbeepingcore.so` per ABI with 16 KB page-size alignment
+  # (required by Android 15+ for apps published after Nov 2025) and
+  # minSdkVersion=24 to match beeping-android (BEE-2221).
+  #
+  # OUTPUT_NAME is forced to lowercase on Android via CMakeLists.txt so the
+  # produced file is `libbeepingcore.so`, matching the JNI loader call
+  # `System.loadLibrary("beepingcore")` in beeping-android/AndroidBeepingCore.
   # ---------------------------------------------------------------------------
   android:
     name: Android NDK (${{ matrix.abi }})
-    # Phase 8 — re-enable when beeping-android SDK task validates end-to-end
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -591,23 +597,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd binutils
 
       - name: Setup Android NDK
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26d
+          ndk-version: r27c
 
       - name: Configure
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_SHARED_LIBS=ON \
             -DBUILD_TESTING=OFF \
+            -DBEEPING_BUILD_CLI=OFF \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
             -DANDROID_ABI=${{ matrix.abi }} \
-            -DANDROID_PLATFORM=android-21 \
+            -DANDROID_PLATFORM=android-24 \
+            -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384" \
             -DCMAKE_INSTALL_PREFIX=install
 
       - name: Build
@@ -615,6 +623,32 @@ jobs:
 
       - name: Install
         run: cmake --install build
+
+      - name: Verify libbeepingcore.so + 16 KB alignment (readelf)
+        run: |
+          set -e
+          SO=$(find install -name "libbeepingcore.so" | head -1)
+          test -f "$SO" || { echo "❌ libbeepingcore.so missing at expected path"; find install -type f; exit 1; }
+          test -d install/include || { echo "❌ include/ headers missing in install tree"; exit 1; }
+          echo "Found: $SO"
+          file "$SO"
+          # -W (wide) prints each program header on a single line so $NF is
+          # always the Align field, regardless of address width (32 vs 64 bit).
+          readelf -W -l "$SO" | tee /tmp/elf.txt
+          # Every PT_LOAD segment must align to >= 0x4000 (16 KB) for Android 15+.
+          # Earlier alignments (0x1000 / 4 KB) trigger UnsatisfiedLinkError on
+          # 16 KB-page devices: "program alignment (4096) cannot be smaller
+          # than system page size (16384)".
+          ALIGNS=$(awk '/^  LOAD/ {print $NF}' /tmp/elf.txt)
+          test -n "$ALIGNS" || { echo "❌ no LOAD segments parsed"; exit 1; }
+          echo "Detected LOAD aligns: $ALIGNS"
+          BAD=$(echo "$ALIGNS" | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
+          if [ -n "$BAD" ]; then
+            echo "❌ ${{ matrix.abi }}: LOAD segments with align < 0x4000 detected:"
+            echo "$BAD"
+            exit 1
+          fi
+          echo "✅ ${{ matrix.abi }}: all LOAD segments aligned to >= 16 KB"
 
       - name: Package
         run: |
@@ -629,6 +663,50 @@ jobs:
           path: |
             beeping-core-android-${{ matrix.abi }}.tar.zst
             beeping-core-android-${{ matrix.abi }}.sha256
+
+  # ---------------------------------------------------------------------------
+  # Android smoke — re-verify each just-published tarball, end-to-end:
+  # extract, confirm shape (libbeepingcore.so + include/ headers), and
+  # re-run the readelf 16 KB alignment assertion against the *packaged*
+  # binary (defends against any packaging step that might strip metadata).
+  # ---------------------------------------------------------------------------
+  android-smoke:
+    name: Android smoke (${{ matrix.abi }})
+    needs: [android]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86_64]
+    steps:
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y zstd binutils
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: beeping-core-android-${{ matrix.abi }}
+          path: artifact
+
+      - name: Extract + verify shape + readelf
+        run: |
+          set -e
+          mkdir -p verify
+          tar --zstd -xf artifact/beeping-core-android-${{ matrix.abi }}.tar.zst -C verify
+          echo "=== tarball contents ==="
+          find verify -maxdepth 4 -type f
+          SO=$(find verify -name "libbeepingcore.so" | head -1)
+          test -f "$SO" || { echo "❌ libbeepingcore.so missing in extracted tarball"; exit 1; }
+          test -d verify/include || { echo "❌ include/ headers missing in extracted tarball"; exit 1; }
+          file "$SO"
+          readelf -W -l "$SO" | grep "^  LOAD"
+          ALIGNS=$(readelf -W -l "$SO" | awk '/^  LOAD/ {print $NF}')
+          test -n "$ALIGNS" || { echo "❌ no LOAD segments parsed"; exit 1; }
+          BAD=$(echo "$ALIGNS" | grep -vE '^0x(4000|8000|10000|20000|40000|80000|100000)$' || true)
+          if [ -n "$BAD" ]; then
+            echo "❌ Tarball ${{ matrix.abi }}: LOAD segment with align < 16 KB: $BAD"
+            exit 1
+          fi
+          echo "✅ ${{ matrix.abi }} tarball OK: libbeepingcore.so + include/ + 16 KB aligned"
 
   # ---------------------------------------------------------------------------
   # iOS — XCFramework (device + simulator)
@@ -789,7 +867,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -829,7 +907,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,150 @@ jobs:
             beeping-core-windows-x64.sha256
 
   # ---------------------------------------------------------------------------
+  # Windows ARM64 — MSVC + Conan + static CRT (/MT)
+  # Native ARM64 binary for Surface Pro ARM, Copilot+ PCs, Parallels on Apple
+  # Silicon. GitHub-hosted runner `windows-11-arm` is currently in public
+  # preview; swap to GA label when promoted.
+  # ---------------------------------------------------------------------------
+  windows-arm64:
+    name: Windows ARM64
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Conan 2.x
+        run: |
+          pip install --upgrade pip
+          pip install "conan>=2.0,<3.0"
+          conan --version
+        shell: pwsh
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-windows-arm64-release-${{ hashFiles('conan.lock') }}
+          restore-keys: |
+            conan-windows-arm64-release-
+
+      - name: Install Conan deps (Release, static MSVC runtime)
+        run: |
+          conan profile detect --force
+          conan install . `
+            --build=missing `
+            --lockfile=conan.lock `
+            -pr:h=./profiles/windows-arm64 `
+            -pr:b=./profiles/windows-arm64 `
+            -s build_type=Release `
+            -s compiler.runtime=static
+        shell: pwsh
+
+      - name: Configure
+        run: |
+          $installDir = Join-Path $env:GITHUB_WORKSPACE "install"
+          cmake --preset conan-default `
+            -DBEEPING_BUILD_CLI=ON `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+            -DBUILD_TESTING=OFF `
+            "-DCMAKE_INSTALL_PREFIX=$installDir"
+        shell: pwsh
+
+      - name: Build
+        run: cmake --build --preset conan-release --config Release
+        shell: pwsh
+
+      - name: Install
+        run: |
+          $installDir = Join-Path $env:GITHUB_WORKSPACE "install"
+          cmake --install build --config Release --prefix "$installDir"
+          Write-Host "Install tree:"
+          Get-ChildItem -Recurse "$installDir" | Select-Object FullName, Length
+        shell: pwsh
+
+      - name: Verify CLI binary exists + static CRT
+        run: |
+          $exePath = Join-Path $env:GITHUB_WORKSPACE "install\bin\beeping-core.exe"
+          Write-Host "Checking: $exePath"
+          if (-not (Test-Path -LiteralPath $exePath)) {
+            Write-Error "❌ CLI binary missing at $exePath"
+            exit 1
+          }
+          Write-Host "✅ Binary present at $exePath"
+
+          # Locate ARM64 dumpbin via vswhere (Hostarm64/arm64 variant).
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $dumpbin = $null
+          if (Test-Path -LiteralPath $vswhere) {
+            $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+            if (-not $vsPath) {
+              $vsPath = & $vswhere -latest -products * -property installationPath
+            }
+            if ($vsPath) {
+              $candidate = Get-ChildItem -Path "$vsPath\VC\Tools\MSVC" -Filter "dumpbin.exe" -Recurse -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match "Hostarm64\\arm64\\dumpbin.exe$" } |
+                Select-Object -First 1
+              if ($candidate) { $dumpbin = $candidate.FullName }
+            }
+          }
+
+          if ($dumpbin) {
+            Write-Host "Using dumpbin: $dumpbin"
+            $deps = & $dumpbin /dependents "$exePath" 2>&1
+            Write-Host "Dependencies of beeping-core.exe:"
+            Write-Host $deps
+            if ($deps -match "VCRUNTIME\d+\.dll|MSVCP\d+\.dll") {
+              Write-Warning "⚠️ Binary depends on VC++ redistributable — expected static CRT."
+            } else {
+              Write-Host "✅ Static CRT confirmed (no VCRUNTIME/MSVCP dynamic deps)"
+            }
+          } else {
+            Write-Warning "dumpbin not found on PATH or via vswhere — skipping static-CRT dependents check (build flags already enforce /MT)."
+          }
+        shell: pwsh
+
+      - name: Smoke-test CLI
+        run: |
+          $exePath = Join-Path $env:GITHUB_WORKSPACE "install\bin\beeping-core.exe"
+          & "$exePath" --help
+          & "$exePath" --version
+        shell: pwsh
+
+      - name: Package (zip)
+        run: |
+          $installDir = Join-Path $env:GITHUB_WORKSPACE "install"
+          $zipPath    = Join-Path $env:GITHUB_WORKSPACE "beeping-core-windows-arm64.zip"
+          $shaPath    = Join-Path $env:GITHUB_WORKSPACE "beeping-core-windows-arm64.sha256"
+          Compress-Archive -Path (Join-Path $installDir "bin"), (Join-Path $installDir "include"), (Join-Path $installDir "lib") -DestinationPath "$zipPath"
+          $hash = (Get-FileHash "$zipPath" -Algorithm SHA256).Hash.ToLower()
+          "$hash  beeping-core-windows-arm64.zip" | Out-File -FilePath "$shaPath" -Encoding ascii
+        shell: pwsh
+
+      - name: Verify CLI in zip
+        run: |
+          $zipPath    = Join-Path $env:GITHUB_WORKSPACE "beeping-core-windows-arm64.zip"
+          $verifyDir  = Join-Path $env:GITHUB_WORKSPACE "verify"
+          Expand-Archive -Path "$zipPath" -DestinationPath "$verifyDir"
+          $verifyExe = Join-Path $verifyDir "bin\beeping-core.exe"
+          if (-not (Test-Path -LiteralPath $verifyExe)) {
+            Write-Error "❌ CLI binary missing in packaged zip at $verifyExe"
+            exit 1
+          }
+          & "$verifyExe" --help
+        shell: pwsh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: beeping-core-windows-arm64
+          path: |
+            beeping-core-windows-arm64.zip
+            beeping-core-windows-arm64.sha256
+
+  # ---------------------------------------------------------------------------
   # Linux — amd64
   # ---------------------------------------------------------------------------
   linux-amd64:
@@ -564,7 +708,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -604,7 +748,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, windows-x64, windows-arm64, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,7 +572,6 @@ jobs:
               /opt/bin/beeping-core --version
               echo '✅ ${{ matrix.image }} arm64 OK'
             "
-            beeping-core-linux-arm64.sha256
 
   # ---------------------------------------------------------------------------
   # Android NDK — arm64-v8a, armeabi-v7a, x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,13 @@ set(BEEPING_CORE_SOURCES
 
 add_library(BeepingCore ${BEEPING_CORE_SOURCES})
 
+# Android JNI loads the library via System.loadLibrary("beepingcore") which
+# resolves to libbeepingcore.so. Force the output name to lowercase only on
+# Android so other platforms keep libBeepingCore.{a,so,dylib,dll} unchanged.
+if(ANDROID)
+  set_target_properties(BeepingCore PROPERTIES OUTPUT_NAME "beepingcore")
+endif()
+
 target_include_directories(BeepingCore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,47 @@ install(EXPORT BeepingCoreTargets
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BeepingCore
 )
 
+# --- WASM target (Emscripten only) --------------------------------------
+# Builds `beeping-core.mjs` + `beeping-core.wasm` as an ES module that
+# exposes the full public C API from BeepingCoreLib_api.h via cwrap/ccall
+# on the JS side. No Embind bindings — the existing C ABI is the web ABI.
+# Installed into `${CMAKE_INSTALL_PREFIX}/wasm/` alongside the JS wrapper,
+# TypeScript defs, demo, and Node smoke test.
+
+if(EMSCRIPTEN)
+  add_executable(beeping_core_wasm wasm/wasm_main.cpp)
+  target_link_libraries(beeping_core_wasm PRIVATE BeepingCore)
+  set_target_properties(beeping_core_wasm PROPERTIES
+    OUTPUT_NAME "beeping-core"
+    SUFFIX ".mjs"
+  )
+  target_link_options(beeping_core_wasm PRIVATE
+    "-O3"
+    "-sMODULARIZE=1"
+    "-sEXPORT_ES6=1"
+    "-sEXPORT_NAME=createBeepingCore"
+    "-sENVIRONMENT=web,worker,node"
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sWASM=1"
+    "-sEXPORTED_FUNCTIONS=['_BEEPING_Create','_BEEPING_Destroy','_BEEPING_Configure','_BEEPING_DecodeAudioBuffer','_BEEPING_GetDecodedData','_BEEPING_GetVersion','_BEEPING_GetConfidence','_BEEPING_GetConfidenceError','_BEEPING_GetConfidenceNoise','_BEEPING_GetReceivedBeepsVolume','_BEEPING_GetDecodedMode','_malloc','_free']"
+    "-sEXPORTED_RUNTIME_METHODS=['cwrap','ccall','HEAPF32','HEAPU8','UTF8ToString','stringToUTF8','lengthBytesUTF8']"
+  )
+
+  install(PROGRAMS
+    $<TARGET_FILE:beeping_core_wasm>
+    "$<TARGET_FILE_DIR:beeping_core_wasm>/beeping-core.wasm"
+    DESTINATION wasm
+  )
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/wasm/beeping-core.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/wasm/beeping-core.d.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/wasm/demo.html
+    ${CMAKE_CURRENT_SOURCE_DIR}/wasm/smoke-test.mjs
+    ${CMAKE_CURRENT_SOURCE_DIR}/wasm/README.md
+    DESTINATION wasm
+  )
+endif()
+
 # --- Docs (Doxygen) ---
 
 find_package(Doxygen)
@@ -153,7 +194,7 @@ FetchContent_MakeAvailable(Catch2)
 
 # --- Tests ---
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT EMSCRIPTEN)
   enable_testing()
 
   set(BEEPING_TEST_SOURCES
@@ -198,7 +239,7 @@ endif()
 
 # --- CLI binary ---
 
-if(BEEPING_BUILD_CLI)
+if(BEEPING_BUILD_CLI AND NOT EMSCRIPTEN)
   add_subdirectory(cli)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ C++20 library for encoding and decoding data over sound (Data Over Sound).
 <!-- Platform validation status -->
 ![macOS](https://img.shields.io/badge/🍎_macOS-validated-brightgreen)
 ![Linux](https://img.shields.io/badge/🐧_Linux-validated-brightgreen)
-![Windows](https://img.shields.io/badge/🪟_Windows-coming_soon-lightgrey)
+![Windows](https://img.shields.io/badge/🪟_Windows-validated-brightgreen)
 ![WASM](https://img.shields.io/badge/🌐_WASM-coming_soon-lightgrey)
 ![iOS](https://img.shields.io/badge/📱_iOS-Phase_9-lightgrey)
 ![Android](https://img.shields.io/badge/🤖_Android-Phase_8-lightgrey)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ C++20 library for encoding and decoding data over sound (Data Over Sound).
 ![Linux](https://img.shields.io/badge/🐧_Linux-validated-brightgreen)
 ![Windows x64](https://img.shields.io/badge/🪟_Windows_x64-validated-brightgreen)
 ![Windows ARM64](https://img.shields.io/badge/🪟_Windows_ARM64-validated-brightgreen)
-![WASM](https://img.shields.io/badge/🌐_WASM-coming_soon-lightgrey)
+![WASM](https://img.shields.io/badge/🌐_WASM-validated-brightgreen)
 ![iOS](https://img.shields.io/badge/📱_iOS-Phase_9-lightgrey)
 ![Android](https://img.shields.io/badge/🤖_Android-Phase_8-lightgrey)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ C++20 library for encoding and decoding data over sound (Data Over Sound).
 <!-- Platform validation status -->
 ![macOS](https://img.shields.io/badge/🍎_macOS-validated-brightgreen)
 ![Linux](https://img.shields.io/badge/🐧_Linux-validated-brightgreen)
-![Windows](https://img.shields.io/badge/🪟_Windows-validated-brightgreen)
+![Windows x64](https://img.shields.io/badge/🪟_Windows_x64-validated-brightgreen)
+![Windows ARM64](https://img.shields.io/badge/🪟_Windows_ARM64-validated-brightgreen)
 ![WASM](https://img.shields.io/badge/🌐_WASM-coming_soon-lightgrey)
 ![iOS](https://img.shields.io/badge/📱_iOS-Phase_9-lightgrey)
 ![Android](https://img.shields.io/badge/🤖_Android-Phase_8-lightgrey)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ C++20 library for encoding and decoding data over sound (Data Over Sound).
 ![Windows x64](https://img.shields.io/badge/🪟_Windows_x64-validated-brightgreen)
 ![Windows ARM64](https://img.shields.io/badge/🪟_Windows_ARM64-validated-brightgreen)
 ![WASM](https://img.shields.io/badge/🌐_WASM-validated-brightgreen)
+![Raspberry Pi](https://img.shields.io/badge/🥧_Raspberry_Pi-ready-brightgreen)
 ![iOS](https://img.shields.io/badge/📱_iOS-Phase_9-lightgrey)
 ![Android](https://img.shields.io/badge/🤖_Android-Phase_8-lightgrey)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | 🍎 macOS (universal arm64 + x86_64) | ✅ Validated | v0.1.0 |
 | 🐧 Linux amd64 (glibc — Ubuntu 22+/24+, Debian 12+, Fedora 41+, Arch) | ✅ Validated | v0.2.0 |
-| 🪟 Windows (x64) | ⏳ Coming | — |
+| 🪟 Windows 11 (x64) | ✅ Validated | v0.3.0 |
 | 🌐 WASM (browser) | ⏳ Coming | — |
 | 🪟 Windows ARM64 | ⏳ Coming | — |
 | 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
@@ -107,6 +107,48 @@ tar --zstd -xf beeping-core-linux-amd64.tar.zst
 ### Not supported: Alpine / musl
 
 Alpine Linux uses musl libc, not glibc — the binary won't run there. If demand surfaces, a separate `beeping-core-linux-amd64-musl.tar.zst` variant will be added in its own task.
+
+## 🪟 Windows (x64)
+
+Validated end-to-end on **Windows 11**. Built with MSVC + **static CRT** (`/MT`) — no VC++ redistributable required. Should also run on Windows 10 1809+ but officially validated on Windows 11 only.
+
+### Download
+
+Replace `v0.3.0` with the latest release tag:
+
+```powershell
+$tag = "v0.3.0"
+Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/beeping-core-windows-x64.zip" -OutFile beeping-core-windows-x64.zip
+Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/SHA256SUMS.txt" -OutFile SHA256SUMS.txt
+```
+
+### Verify
+
+```powershell
+$expected = (Get-Content SHA256SUMS.txt | Select-String "beeping-core-windows-x64.zip").ToString().Split(" ")[0]
+$actual = (Get-FileHash beeping-core-windows-x64.zip -Algorithm SHA256).Hash.ToLower()
+if ($expected -eq $actual) { Write-Host "✅ OK" } else { Write-Error "❌ Mismatch" }
+```
+
+### Extract
+
+```powershell
+Expand-Archive -Path .\beeping-core-windows-x64.zip -DestinationPath beeping-core
+```
+
+### Run the CLI
+
+```powershell
+.\beeping-core\bin\beeping-core.exe --help
+.\beeping-core\bin\beeping-core.exe --version
+.\beeping-core\bin\beeping-core.exe decode path\to\sound.wav
+```
+
+If Windows Defender SmartScreen warns: right-click the file → Properties → check "Unblock" at the bottom → OK. This is because the binary isn't code-signed yet (Authenticode signing will come in a later phase).
+
+### Windows ARM64
+
+Not yet supported. Planned as a separate release (BEE-1732). Runs on x64 Windows via emulation in the meantime.
 
 ## Other platforms
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@
 | 🪟 Windows 11 (x64) | ✅ Validated | v0.3.1 |
 | 🪟 Windows 11 (ARM64) | ✅ Validated | v0.4.0 |
 | 🌐 WASM (browser + Node) | ✅ Validated | v0.5.0 |
-| 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
+| 🥧 Linux arm64 / Raspberry Pi (Pi 4 / Pi 5 / Pi Zero 2 W) | ✅ Validated | v0.6.0 |
 | 📱 iOS XCFramework | ⏳ Phase 9 | — |
 | 🤖 Android NDK | ⏳ Phase 8 | — |
 | 🏔️ Alpine Linux / musl | ❌ Not supported (glibc-only build) | — |
@@ -180,6 +180,66 @@ Expand-Archive -Path .\beeping-core-windows-arm64.zip -DestinationPath beeping-c
 ```
 
 If your ARM64 Windows is running an x64 build of `beeping-core` under Prism emulation, decoding still works but isn't native. Prefer the ARM64 build for best battery + performance.
+
+## 🥧 Linux arm64 / Raspberry Pi
+
+Validated end-to-end on the GitHub-hosted **`ubuntu-22.04-arm`** runner and
+smoke-tested against Ubuntu 22.04/24.04, Debian 12 (== Raspberry Pi OS
+bookworm base), Fedora 41 and Arch — all arm64. Built against glibc 2.35 +
+`-static-libgcc -static-libstdc++`, so the binary runs on any arm64 Linux
+with glibc 2.35+.
+
+Supported hardware:
+
+| Model | Arch | OS | Status |
+|---|---|---|---|
+| Raspberry Pi 4 / 400 | BCM2711 (ARMv8-A) | Raspberry Pi OS 64-bit · Ubuntu arm64 | ✅ |
+| Raspberry Pi 5 | BCM2712 (ARMv8.2-A) | Raspberry Pi OS 64-bit · Ubuntu arm64 | ✅ |
+| Raspberry Pi Zero 2 W | BCM2710 (ARMv8-A) | Raspberry Pi OS 64-bit | ✅ |
+| Generic Linux arm64 (Ampere, AWS Graviton, Oracle Ampere, Jetson, Pine64, Rock Pi) | ARMv8+ | any glibc 2.35+ | ✅ |
+
+32-bit Raspberry Pi OS (armhf) is **not supported** — flash the 64-bit
+image from Raspberry Pi Imager.
+
+### Download
+
+```bash
+TAG=v0.6.0
+curl -LO "https://github.com/beeping-io/beeping-core/releases/download/${TAG}/beeping-core-linux-arm64.tar.zst"
+curl -LO "https://github.com/beeping-io/beeping-core/releases/download/${TAG}/SHA256SUMS.txt"
+```
+
+### Verify
+
+```bash
+sha256sum -c SHA256SUMS.txt --ignore-missing
+```
+
+Expected: `beeping-core-linux-arm64.tar.zst: OK`.
+
+### Extract
+
+```bash
+# Raspberry Pi OS / Debian: install zstd if needed
+sudo apt-get install -y zstd
+
+tar --zstd -xf beeping-core-linux-arm64.tar.zst
+```
+
+### Run the CLI
+
+```bash
+./bin/beeping-core --help
+./bin/beeping-core --version
+./bin/beeping-core decode path/to/sound.wav
+```
+
+First-run sanity check on a Pi:
+
+```bash
+file ./bin/beeping-core
+# ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, ...
+```
 
 ## 🌐 WASM (browser + Node.js)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | 🍎 macOS (universal arm64 + x86_64) | ✅ Validated | v0.1.0 |
 | 🐧 Linux amd64 (glibc — Ubuntu 22+/24+, Debian 12+, Fedora 41+, Arch) | ✅ Validated | v0.2.0 |
-| 🪟 Windows 11 (x64) | ✅ Validated | v0.3.0 |
+| 🪟 Windows 11 (x64) | ✅ Validated | v0.3.1 |
 | 🌐 WASM (browser) | ⏳ Coming | — |
 | 🪟 Windows ARM64 | ⏳ Coming | — |
 | 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
@@ -114,10 +114,10 @@ Validated end-to-end on **Windows 11**. Built with MSVC + **static CRT** (`/MT`)
 
 ### Download
 
-Replace `v0.3.0` with the latest release tag:
+Replace `v0.3.1` with the latest release tag:
 
 ```powershell
-$tag = "v0.3.0"
+$tag = "v0.3.1"
 Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/beeping-core-windows-x64.zip" -OutFile beeping-core-windows-x64.zip
 Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/SHA256SUMS.txt" -OutFile SHA256SUMS.txt
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -9,8 +9,8 @@
 | 🍎 macOS (universal arm64 + x86_64) | ✅ Validated | v0.1.0 |
 | 🐧 Linux amd64 (glibc — Ubuntu 22+/24+, Debian 12+, Fedora 41+, Arch) | ✅ Validated | v0.2.0 |
 | 🪟 Windows 11 (x64) | ✅ Validated | v0.3.1 |
+| 🪟 Windows 11 (ARM64) | ✅ Validated | v0.4.0 |
 | 🌐 WASM (browser) | ⏳ Coming | — |
-| 🪟 Windows ARM64 | ⏳ Coming | — |
 | 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
 | 📱 iOS XCFramework | ⏳ Phase 9 | — |
 | 🤖 Android NDK | ⏳ Phase 8 | — |
@@ -146,9 +146,40 @@ Expand-Archive -Path .\beeping-core-windows-x64.zip -DestinationPath beeping-cor
 
 If Windows Defender SmartScreen warns: right-click the file → Properties → check "Unblock" at the bottom → OK. This is because the binary isn't code-signed yet (Authenticode signing will come in a later phase).
 
-### Windows ARM64
+## 🪟 Windows (ARM64)
 
-Not yet supported. Planned as a separate release (BEE-1732). Runs on x64 Windows via emulation in the meantime.
+Validated end-to-end on **Windows 11 ARM64**. Built with MSVC ARM64 target + **static CRT** (`/MT`). Native ARM64 — no x64 emulation overhead.
+
+Target hardware: Surface Pro (ARM64), Copilot+ PCs (Snapdragon X Elite/Plus), Parallels/UTM running Windows 11 on Apple Silicon.
+
+### Download
+
+Replace `v0.4.0` with the latest release tag:
+
+```powershell
+$tag = "v0.4.0"
+Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/beeping-core-windows-arm64.zip" -OutFile beeping-core-windows-arm64.zip
+Invoke-WebRequest -Uri "https://github.com/beeping-io/beeping-core/releases/download/$tag/SHA256SUMS.txt" -OutFile SHA256SUMS.txt
+```
+
+### Verify
+
+```powershell
+$expected = (Get-Content SHA256SUMS.txt | Select-String "beeping-core-windows-arm64.zip").ToString().Split(" ")[0]
+$actual = (Get-FileHash beeping-core-windows-arm64.zip -Algorithm SHA256).Hash.ToLower()
+if ($expected -eq $actual) { Write-Host "✅ OK" } else { Write-Error "❌ Mismatch" }
+```
+
+### Extract + run
+
+```powershell
+Expand-Archive -Path .\beeping-core-windows-arm64.zip -DestinationPath beeping-core
+.\beeping-core\bin\beeping-core.exe --help
+.\beeping-core\bin\beeping-core.exe --version
+.\beeping-core\bin\beeping-core.exe decode path\to\sound.wav
+```
+
+If your ARM64 Windows is running an x64 build of `beeping-core` under Prism emulation, decoding still works but isn't native. Prefer the ARM64 build for best battery + performance.
 
 ## Other platforms
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,7 +10,7 @@
 | 🐧 Linux amd64 (glibc — Ubuntu 22+/24+, Debian 12+, Fedora 41+, Arch) | ✅ Validated | v0.2.0 |
 | 🪟 Windows 11 (x64) | ✅ Validated | v0.3.1 |
 | 🪟 Windows 11 (ARM64) | ✅ Validated | v0.4.0 |
-| 🌐 WASM (browser) | ⏳ Coming | — |
+| 🌐 WASM (browser + Node) | ✅ Validated | v0.5.0 |
 | 🥧 Raspberry Pi / Linux ARM64 | ⏳ Coming | — |
 | 📱 iOS XCFramework | ⏳ Phase 9 | — |
 | 🤖 Android NDK | ⏳ Phase 8 | — |
@@ -180,6 +180,55 @@ Expand-Archive -Path .\beeping-core-windows-arm64.zip -DestinationPath beeping-c
 ```
 
 If your ARM64 Windows is running an x64 build of `beeping-core` under Prism emulation, decoding still works but isn't native. Prefer the ARM64 build for best battery + performance.
+
+## 🌐 WASM (browser + Node.js)
+
+Decode WAVs in the browser or Node without any native binary. Ships as
+an ES module (`beeping-core.mjs` + `beeping-core.wasm` + a thin JS
+wrapper `beeping-core.js`) plus TypeScript definitions.
+
+### Download
+
+```bash
+TAG=v0.5.0
+curl -LO "https://github.com/beeping-io/beeping-core/releases/download/${TAG}/beeping-core-wasm.tar.zst"
+curl -LO "https://github.com/beeping-io/beeping-core/releases/download/${TAG}/SHA256SUMS.txt"
+shasum -a 256 -c SHA256SUMS.txt --ignore-missing
+tar --zstd -xf beeping-core-wasm.tar.zst
+```
+
+### Browser usage
+
+```js
+// 1. Copy wasm/ next to your app, served over HTTPS with
+//    Content-Type: application/wasm for the .wasm file.
+import { decode } from "./wasm/beeping-core.js";
+
+const file = document.querySelector("input[type=file]").files[0];
+const payload = await decode(await file.arrayBuffer());
+console.log(payload); // "h3l7m0000"
+```
+
+### Node.js usage
+
+```bash
+node wasm/smoke-test.mjs path/to/sound.wav h3l7m0000
+```
+
+Or programmatically:
+
+```js
+import { readFile } from "node:fs/promises";
+import { decode } from "./wasm/beeping-core.js";
+
+const buf = await readFile("sound.wav");
+const payload = await decode(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength));
+```
+
+### Demo
+
+Open `wasm/demo.html` over HTTPS (or a local static server) and drop a
+WAV onto the page. Full source is in the tarball.
 
 ## Other platforms
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -185,9 +185,10 @@ If your ARM64 Windows is running an x64 build of `beeping-core` under Prism emul
 
 Validated end-to-end on the GitHub-hosted **`ubuntu-22.04-arm`** runner and
 smoke-tested against Ubuntu 22.04/24.04, Debian 12 (== Raspberry Pi OS
-bookworm base), Fedora 41 and Arch — all arm64. Built against glibc 2.35 +
+bookworm base) and Fedora 41 — all arm64. Built against glibc 2.35 +
 `-static-libgcc -static-libstdc++`, so the binary runs on any arm64 Linux
-with glibc 2.35+.
+with glibc 2.35+. Arch Linux ARM is a separate community project; the
+binary should also run there but it isn't part of the smoke matrix.
 
 Supported hardware:
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -10,9 +10,9 @@
 | 🍎 macOS | arm64 + x86_64 universal | `beeping-core-macos-universal.tar.zst` |
 | 🐧 Linux | amd64 | `beeping-core-linux-amd64.tar.zst` |
 | 🐧 Linux | arm64 | `beeping-core-linux-arm64.tar.zst` |
-| 🤖 Android NDK | arm64-v8a | `beeping-core-android-arm64-v8a.tar.zst` |
-| 🤖 Android NDK | armeabi-v7a | `beeping-core-android-armeabi-v7a.tar.zst` |
-| 🤖 Android NDK | x86_64 | `beeping-core-android-x86_64.tar.zst` |
+| 🤖 Android NDK | arm64-v8a (16 KB pages, minSdk 24) | `beeping-core-android-arm64-v8a.tar.zst` |
+| 🤖 Android NDK | armeabi-v7a (16 KB pages, minSdk 24) | `beeping-core-android-armeabi-v7a.tar.zst` |
+| 🤖 Android NDK | x86_64 (16 KB pages, minSdk 24) | `beeping-core-android-x86_64.tar.zst` |
 | 🍎 iOS | device + simulator | `beeping-core-ios-xcframework.tar.zst` |
 | 🌐 WASM | Emscripten | `beeping-core-wasm.tar.zst` |
 
@@ -56,6 +56,14 @@ tar --zstd -xf beeping-core-macos-universal.tar.zst
 # iOS (XCFramework)
 tar --zstd -xf beeping-core-ios-xcframework.tar.zst
 # Now you have: BeepingCore.xcframework — drag into Xcode
+
+# Android NDK (one tarball per ABI)
+tar --zstd -xf beeping-core-android-arm64-v8a.tar.zst
+# Now you have: lib/libbeepingcore.so + include/BeepingCoreLib_api.h
+# The .so is built with -Wl,-z,max-page-size=16384 for Android 15+ 16 KB pages
+# and named lowercase to match System.loadLibrary("beepingcore"). Drop into
+# app/src/main/jniLibs/<abi>/libbeepingcore.so. See docs/verifying-releases.md
+# section 5 for the readelf 16 KB alignment check.
 ```
 
 ## Triggering a release

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -13,7 +13,7 @@
 | 🤖 Android NDK | arm64-v8a (16 KB pages, minSdk 24) | `beeping-core-android-arm64-v8a.tar.zst` |
 | 🤖 Android NDK | armeabi-v7a (16 KB pages, minSdk 24) | `beeping-core-android-armeabi-v7a.tar.zst` |
 | 🤖 Android NDK | x86_64 (16 KB pages, minSdk 24) | `beeping-core-android-x86_64.tar.zst` |
-| 🍎 iOS | device + simulator | `beeping-core-ios-xcframework.tar.zst` |
+| 🍎 iOS | device arm64 + simulator universal (arm64 + x86_64), iOS 13+, RelWithDebInfo (DWARF embedded) | `beeping-core-ios-xcframework.tar.zst` |
 | 🌐 WASM | Emscripten | `beeping-core-wasm.tar.zst` |
 
 Each release also includes:
@@ -63,7 +63,7 @@ tar --zstd -xf beeping-core-android-arm64-v8a.tar.zst
 # The .so is built with -Wl,-z,max-page-size=16384 for Android 15+ 16 KB pages
 # and named lowercase to match System.loadLibrary("beepingcore"). Drop into
 # app/src/main/jniLibs/<abi>/libbeepingcore.so. See docs/verifying-releases.md
-# section 5 for the readelf 16 KB alignment check.
+# section 6 for the readelf 16 KB alignment check.
 ```
 
 ## Triggering a release

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -202,6 +202,63 @@ echo "✅ All verifications passed for $ARTIFACT"
 
 ---
 
+## 5. 🤖 Android-specific: 16 KB page-size verification
+
+Android 15+ enforces 16 KB memory pages on apps published after Nov 2025.
+The Android NDK shared libraries shipped by `beeping-core`
+(`beeping-core-android-{arm64-v8a,armeabi-v7a,x86_64}.tar.zst`) are linked
+with `-Wl,-z,max-page-size=16384`, but you can re-confirm it locally with
+`readelf` from `binutils`.
+
+```bash
+# 1. Download + extract a per-ABI tarball
+ABI=arm64-v8a   # or armeabi-v7a, x86_64
+ARTIFACT=beeping-core-android-$ABI.tar.zst
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+
+# 2. (Recommended) verify cosign signature first — same flow as section 2
+cosign verify-blob \
+  --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --signature $ARTIFACT.sig \
+  $ARTIFACT
+
+# 3. Extract and inspect ELF program headers
+mkdir -p extract && tar --zstd -xf $ARTIFACT -C extract
+SO=$(find extract -name "libbeepingcore.so" | head -1)
+readelf -W -l "$SO" | grep "^  LOAD"
+```
+
+Use `readelf -W` (wide) so each program header is printed on a single
+line — the default output splits a LOAD record across two lines, which
+hides the Align column.
+
+Each `LOAD` segment must show alignment `>= 0x4000` (16 KB) in the last
+column:
+
+```text
+  LOAD  0x000000 0x00000000 0x00000000 0x13a270 0x13a270 R E 0x4000   ✅
+  LOAD  0x13a270 0x0013e270 0x0013e270 0x00a2e0 0x00ad90 RW  0x4000   ✅
+  LOAD  0x144550 0x0014c550 0x0014c550 0x0002e8 0x002440 RW  0x4000   ✅
+```
+
+If you see `0x1000` (4 KB) instead, the binary will fail to load at runtime
+on Android 15+ devices with the error:
+
+```text
+java.lang.UnsatisfiedLinkError: dlopen failed:
+"libbeepingcore.so" program alignment (4096) cannot be smaller than
+system page size (16384)
+```
+
+CI guards this in two places: an inline `readelf` check in the `android`
+job (build-time) and a separate `android-smoke` job that re-validates the
+*packaged* tarball post-upload, so a release with a broken alignment
+cannot be published.
+
+---
+
 ## Reporting issues
 
 If any verification fails unexpectedly, do not run the binary. Open an issue at

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -202,7 +202,73 @@ echo "✅ All verifications passed for $ARTIFACT"
 
 ---
 
-## 5. 🤖 Android-specific: 16 KB page-size verification
+## 5. 🍎 iOS-specific: XCFramework structure verification
+
+The iOS artifact `beeping-core-ios-xcframework.tar.zst` ships a single
+`BeepingCore.xcframework` directory containing two slices:
+
+| Slice | Architecture(s) | Use |
+|---|---|---|
+| `ios-arm64` | `arm64` | Real iPhones / iPads |
+| `ios-arm64_x86_64-simulator` | `arm64` + `x86_64` (universal) | Simulator on Apple Silicon **and** legacy Intel Macs |
+
+Verify locally with `lipo` (bundled with Xcode) and `plutil`:
+
+```bash
+RELEASE=v1.0.0
+ARTIFACT=beeping-core-ios-xcframework.tar.zst
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+
+# (Recommended) cosign verify first — same flow as section 2
+cosign verify-blob \
+  --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --signature $ARTIFACT.sig \
+  $ARTIFACT
+
+# Extract + inspect
+mkdir -p extract && tar --zstd -xf $ARTIFACT -C extract
+XCFW=extract/BeepingCore.xcframework
+
+# Info.plist must be a valid plist
+plutil -lint "$XCFW/Info.plist"
+
+# Each slice must carry the expected architectures
+lipo -archs "$XCFW/ios-arm64/libBeepingCore.a"
+# → arm64
+lipo -archs "$XCFW/ios-arm64_x86_64-simulator/libBeepingCore.a"
+# → x86_64 arm64
+```
+
+If `lipo -archs` reports an unexpected architecture set (e.g. only
+`arm64` on the simulator slice), you have a partial XCFramework —
+Apple Silicon devs would still be fine but the package would not load
+in the simulator on legacy Intel Macs. CI guards both invariants in two
+places (the `ios` build job + the `ios-smoke` post-package job) so a
+release with a malformed XCFramework cannot be published.
+
+To consume the XCFramework: drop it into your Xcode project, link
+`BeepingCore.xcframework` from the Frameworks build phase, and import
+the C API headers (`BeepingCoreLib_api.h`) from a bridging header or
+modulemap.
+
+The shipped slices are built with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`
+(`-O2 -g -DNDEBUG`), so DWARF debug info is embedded in the static
+archives. When you archive your app, Xcode picks up those symbols and
+emits a `.dSYM` for `BeepingCore` alongside the one for your app —
+crash reports from production users will be fully symbolicatable.
+You can confirm DWARF presence with `dwarfdump` (bundled with Xcode):
+
+```bash
+DEV=BeepingCore.xcframework/ios-arm64/libBeepingCore.a
+dwarfdump --debug-info "$DEV" | grep -c "TAG_compile_unit"
+# expected: ≥ 5  (one DWARF compile unit per .o; a healthy slice has dozens)
+```
+
+---
+
+## 6. 🤖 Android-specific: 16 KB page-size verification
 
 Android 15+ enforces 16 KB memory pages on apps published after Nov 2025.
 The Android NDK shared libraries shipped by `beeping-core`

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,46 @@
+# beeping-core — WASM decoder
+
+Pre-built ES-module bundle that decodes Beeping WAVs entirely in the
+browser (or Node.js). No server, no `<audio>` element, no network call
+after the module loads.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `beeping-core.wasm` | Compiled BeepingCore C++20 library (Emscripten, `-O3`, `/MT`-equivalent). |
+| `beeping-core.mjs`  | Emscripten ES-module glue emitted alongside the `.wasm`. |
+| `beeping-core.js`   | Thin high-level wrapper: parses WAV (PCM int16 / float32, mono/stereo) and streams samples into the C API. |
+| `beeping-core.d.ts` | TypeScript types for `beeping-core.js`. |
+| `demo.html`         | Drag-and-drop browser demo — open it over HTTPS or via a local static server. |
+| `smoke-test.mjs`    | Node.js smoke test (gating job in CI). |
+
+## Usage
+
+```js
+import { decode } from "./beeping-core.js";
+
+const file = document.querySelector("input[type=file]").files[0];
+const payload = await decode(await file.arrayBuffer());
+console.log(payload); // e.g. "h3l7m0000"
+```
+
+`decode()` resolves to the payload string, or `null` if no beep was
+detected. Pass a mode override as the second argument:
+
+```js
+import { decode, BEEPING_MODE_AUDIBLE } from "./beeping-core.js";
+await decode(buf, BEEPING_MODE_AUDIBLE);
+```
+
+## Serving
+
+`beeping-core.wasm` must be served with MIME `application/wasm`. Most
+static hosts (Firebase Hosting, GitHub Pages, Cloudflare Pages, S3
+with the right content-type) handle this by default. If you bundle it
+into a Vite/Webpack app, import the `.mjs` directly — the bundler will
+wire the `.wasm` path.
+
+CORS: the module is same-origin by default. If you load it from a
+different origin, the host must send `Access-Control-Allow-Origin: *`
+(or the right allow-list) on both the `.mjs` and `.wasm`.

--- a/wasm/beeping-core.d.ts
+++ b/wasm/beeping-core.d.ts
@@ -1,0 +1,17 @@
+/** BEEPING_MODE enum values mirrored from BeepingCoreLib_api.h. */
+export const BEEPING_MODE_AUDIBLE: 2;
+export const BEEPING_MODE_INAUDIBLE: 3;
+export const BEEPING_MODE_ALL: 5;
+
+/**
+ * Decode a WAV buffer and return its Beeping payload, or `null` if no
+ * beep was detected. The WAV must be PCM int16 or IEEE float32, mono
+ * or stereo (stereo is downmixed to mono).
+ *
+ * @param wavBuffer Raw WAV file bytes.
+ * @param mode      BEEPING_MODE_* selector (defaults to BEEPING_MODE_ALL).
+ */
+export function decode(
+  wavBuffer: ArrayBuffer,
+  mode?: 2 | 3 | 5,
+): Promise<string | null>;

--- a/wasm/beeping-core.js
+++ b/wasm/beeping-core.js
@@ -1,0 +1,143 @@
+// High-level ES-module wrapper around the Emscripten-compiled BeepingCore.
+//
+// The low-level WASM module is emitted next to this file as
+// `beeping-core.mjs` + `beeping-core.wasm`. This wrapper parses a WAV
+// payload on the JS side (mono or stereo, PCM int16 or IEEE float32) and
+// streams the samples into the C decoder in 1024-sample chunks — the
+// same chunking the CLI uses, so the behaviour matches the native
+// binaries.
+//
+// Usage:
+//   import { decode } from "./beeping-core.js";
+//   const payload = await decode(await file.arrayBuffer());
+
+import createBeepingCore from "./beeping-core.mjs";
+
+export const BEEPING_MODE_AUDIBLE   = 2;
+export const BEEPING_MODE_INAUDIBLE = 3;
+export const BEEPING_MODE_ALL       = 5;
+
+const kBufferSize = 1024;
+
+let _modulePromise = null;
+function loadModule() {
+  if (!_modulePromise) _modulePromise = createBeepingCore();
+  return _modulePromise;
+}
+
+function parseWav(arrayBuffer) {
+  const view = new DataView(arrayBuffer);
+  const tag = (o) =>
+    String.fromCharCode(view.getUint8(o), view.getUint8(o+1), view.getUint8(o+2), view.getUint8(o+3));
+  if (tag(0) !== "RIFF" || tag(8) !== "WAVE") {
+    throw new Error("Not a RIFF/WAVE file");
+  }
+
+  let fmt = null;
+  let data = null;
+  let offset = 12;
+  while (offset + 8 <= view.byteLength) {
+    const id = tag(offset);
+    const size = view.getUint32(offset + 4, true);
+    const body = offset + 8;
+    if (id === "fmt ") {
+      fmt = {
+        format:        view.getUint16(body, true),
+        channels:      view.getUint16(body + 2, true),
+        sampleRate:    view.getUint32(body + 4, true),
+        bitsPerSample: view.getUint16(body + 14, true),
+      };
+    } else if (id === "data") {
+      data = { offset: body, size };
+    }
+    offset = body + size + (size % 2);
+  }
+  if (!fmt || !data) throw new Error("Missing fmt or data chunk");
+
+  const bytesPerSample = fmt.bitsPerSample / 8;
+  const frames = Math.floor(data.size / bytesPerSample / fmt.channels);
+  const samples = new Float32Array(frames);
+
+  if (fmt.format === 1 && fmt.bitsPerSample === 16) {
+    let pos = data.offset;
+    for (let i = 0; i < frames; i++) {
+      let sum = 0;
+      for (let c = 0; c < fmt.channels; c++) {
+        sum += view.getInt16(pos, true) / 32768;
+        pos += bytesPerSample;
+      }
+      samples[i] = sum / fmt.channels;
+    }
+  } else if (fmt.format === 3 && fmt.bitsPerSample === 32) {
+    let pos = data.offset;
+    for (let i = 0; i < frames; i++) {
+      let sum = 0;
+      for (let c = 0; c < fmt.channels; c++) {
+        sum += view.getFloat32(pos, true);
+        pos += bytesPerSample;
+      }
+      samples[i] = sum / fmt.channels;
+    }
+  } else {
+    throw new Error(
+      `Unsupported WAV format=${fmt.format} bitsPerSample=${fmt.bitsPerSample} ` +
+      `(expected PCM int16 or IEEE float32)`);
+  }
+
+  return { sampleRate: fmt.sampleRate, samples };
+}
+
+/**
+ * Decode a beeping WAV buffer and return its payload, or `null` if no
+ * beep was detected.
+ *
+ * @param {ArrayBuffer} wavBuffer  Raw WAV file bytes.
+ * @param {number} [mode=5]        BEEPING_MODE_* selector.
+ * @returns {Promise<string|null>}
+ */
+export async function decode(wavBuffer, mode = BEEPING_MODE_ALL) {
+  const M = await loadModule();
+  const wav = parseWav(wavBuffer);
+
+  const create    = M.cwrap("BEEPING_Create",            "number", []);
+  const destroy   = M.cwrap("BEEPING_Destroy",            null,     ["number"]);
+  const configure = M.cwrap("BEEPING_Configure",          "number", ["number", "number", "number", "number"]);
+  const feed      = M.cwrap("BEEPING_DecodeAudioBuffer",  "number", ["number", "number", "number"]);
+  const getData   = M.cwrap("BEEPING_GetDecodedData",     "number", ["number", "number"]);
+
+  const handle = create();
+  if (!handle) throw new Error("BEEPING_Create failed");
+
+  if (configure(mode, wav.sampleRate, kBufferSize, handle) !== 0) {
+    destroy(handle);
+    throw new Error(`BEEPING_Configure failed (mode=${mode} sr=${wav.sampleRate})`);
+  }
+
+  const bufPtr  = M._malloc(kBufferSize * 4);
+  const outPtr  = M._malloc(32);
+  try {
+    let decoded = false;
+    for (let i = 0; i < wav.samples.length && !decoded; i += kBufferSize) {
+      const chunk = Math.min(kBufferSize, wav.samples.length - i);
+      M.HEAPF32.set(wav.samples.subarray(i, i + chunk), bufPtr / 4);
+      if (feed(bufPtr, chunk, handle) === -3) decoded = true;
+    }
+
+    // Flush trailing silence — same pattern the CLI uses (decode_cmd.cpp).
+    if (!decoded) {
+      M.HEAPF32.fill(0, bufPtr / 4, bufPtr / 4 + kBufferSize);
+      for (let f = 0; f < 200 && !decoded; f++) {
+        if (feed(bufPtr, kBufferSize, handle) === -3) decoded = true;
+      }
+    }
+    if (!decoded) return null;
+
+    const len = getData(outPtr, handle);
+    if (len <= 0) return null;
+    return M.UTF8ToString(outPtr, len);
+  } finally {
+    M._free(bufPtr);
+    M._free(outPtr);
+    destroy(handle);
+  }
+}

--- a/wasm/demo.html
+++ b/wasm/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>beeping-core — WASM decoder demo</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
+    h1 { margin-bottom: 0.25rem; }
+    .drop { border: 2px dashed #9aa; border-radius: 12px; padding: 3rem 1rem; text-align: center; color: #667; cursor: pointer; transition: all 0.15s; user-select: none; }
+    .drop:hover, .drop.over { border-color: #36c; background: rgba(51, 102, 204, 0.08); color: #222; }
+    .drop code { background: rgba(128,128,128,0.18); padding: 0.1em 0.35em; border-radius: 4px; }
+    pre { background: #0b0f1a; color: #8fe; padding: 1rem 1.25rem; border-radius: 8px; white-space: pre-wrap; word-break: break-word; min-height: 3em; margin-top: 1.25rem; }
+    footer { margin-top: 2.5rem; color: #888; font-size: 0.85rem; }
+    footer a { color: inherit; }
+  </style>
+</head>
+<body>
+  <h1>🔊 beeping-core WASM decoder</h1>
+  <p>Drop a <code>.wav</code> below. Decoding runs entirely in your browser — no network calls after the initial module load.</p>
+
+  <div id="drop" class="drop">
+    Drop a <code>.wav</code> file here, or click to choose
+  </div>
+  <input id="pick" type="file" accept=".wav,audio/wav,audio/wave,audio/x-wav" hidden>
+
+  <pre id="out">Waiting for a WAV…</pre>
+
+  <footer>
+    <p>
+      Module: <code>beeping-core.wasm</code> +
+      <a href="./beeping-core.js"><code>beeping-core.js</code></a>. Source:
+      <a href="https://github.com/beeping-io/beeping-core">beeping-io/beeping-core</a>.
+    </p>
+  </footer>
+
+  <script type="module">
+    import { decode } from "./beeping-core.js";
+
+    const drop = document.getElementById("drop");
+    const pick = document.getElementById("pick");
+    const out  = document.getElementById("out");
+
+    drop.addEventListener("click", () => pick.click());
+    drop.addEventListener("dragover",  e => { e.preventDefault(); drop.classList.add("over"); });
+    drop.addEventListener("dragleave", ()  => drop.classList.remove("over"));
+    drop.addEventListener("drop",      e => {
+      e.preventDefault();
+      drop.classList.remove("over");
+      handle(e.dataTransfer?.files?.[0]);
+    });
+    pick.addEventListener("change", () => handle(pick.files?.[0]));
+
+    async function handle(file) {
+      if (!file) return;
+      out.textContent = `Decoding ${file.name} (${(file.size / 1024).toFixed(1)} KB)…`;
+      try {
+        const t0 = performance.now();
+        const payload = await decode(await file.arrayBuffer());
+        const dt = (performance.now() - t0).toFixed(1);
+        out.textContent = payload
+          ? `✅ Decoded in ${dt} ms\n\n  payload: ${payload}`
+          : `❌ No beep detected (tried for ${dt} ms)`;
+      } catch (err) {
+        out.textContent = `❌ Error: ${err.message}`;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/wasm/smoke-test.mjs
+++ b/wasm/smoke-test.mjs
@@ -1,0 +1,24 @@
+// Node.js smoke test — used by the WASM release job to gate the build.
+// Usage:
+//   node smoke-test.mjs <wav-file> <expected-payload>
+
+import { readFile } from "node:fs/promises";
+import { decode } from "./beeping-core.js";
+
+const [wavPath, expected] = process.argv.slice(2);
+if (!wavPath || !expected) {
+  console.error("usage: node smoke-test.mjs <wav> <expected>");
+  process.exit(2);
+}
+
+const buf = await readFile(wavPath);
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+const payload = await decode(ab);
+
+if (payload === expected) {
+  console.log(`✅ decoded '${payload}' (expected '${expected}')`);
+  process.exit(0);
+} else {
+  console.error(`❌ got ${JSON.stringify(payload)}, expected '${expected}'`);
+  process.exit(1);
+}

--- a/wasm/wasm_main.cpp
+++ b/wasm/wasm_main.cpp
@@ -1,0 +1,10 @@
+// Emscripten entry point for the WASM build of BeepingCore.
+//
+// Emscripten requires a `main` to link a "binary" module. The C API in
+// include/BeepingCoreLib_api.h is kept alive from JavaScript via
+// `-sEXPORTED_FUNCTIONS=['_BEEPING_*','_malloc','_free']` in release.yml
+// (mirrored in CMakeLists.txt). No new bindings are needed — the
+// existing C ABI is the web ABI.
+#include <BeepingCoreLib_api.h>
+
+int main() { return 0; }


### PR DESCRIPTION
## Summary

Promotes 12 commits accumulated on `develop` since the last `main`
sync (PR #13, last release `v0.6.0`). Once merged, `release-please.yml`
will open a version-bump PR for **v0.7.0** (no `feat!:` so MINOR bump
matches semver + the 0.x pre-1.0 rule documented in the global
methodology). That PR's merge fires the `release.yml` tag pipeline.

## What ships in v0.7.0

| Area | BEE | What |
|---|---|---|
| 🪟 Windows | BEE-1730 (#14, #15, #16, #17, #18) | Windows x64 release with static CRT (/MT) — zero-dependency portable binary; CI-side fixes for cmake install path + dumpbin discovery + zip packaging |
| 🪟 Windows | BEE-1732 (#19) | Windows ARM64 release on `windows-11-arm` runner |
| 🌐 WASM | BEE-1731 (#20) | WASM browser + Node decoder (Emscripten 3.1.64) with Node smoke-test on real WAVs |
| 🐧 Linux arm64 | BEE-1696 (#21, #22, #23) | Linux arm64 / Raspberry Pi target with native ARM runner + 4-distro compat smoke (no archlinux upstream) |
| 🤖 Android | BEE-2221 (#24) | Android NDK `.so` for arm64-v8a + armeabi-v7a + x86_64, 16 KB page-aligned (Android 15+ requirement), `libbeepingcore.so` lowercase to match `System.loadLibrary("beepingcore")` |
| 🍎 iOS | BEE-2223 (#25) | XCFramework with `ios-arm64` device + `ios-arm64_x86_64-simulator` universal slice, RelWithDebInfo (DWARF embedded for production crash symbolication) |

## What this unblocks downstream

- Phase 8 (`beeping-android`) — **BEE-65** (consume `.so` from GH Releases instead of vendored binaries) gets real signed artifacts at a stable URL
- Phase 9 (`beeping-ios`) — **BEE-80** (Swift Package + `.binaryTarget`) and **BEE-82** (release-please + cosign + GH Releases con XCFramework firmado) get a versioned XCFramework to point `.binaryTarget(name: "BeepingCore", url: ..., checksum: ...)` at
- Phase 14/15 (`beeping-cli` Rust) — already consumes from GH Releases via `build.rs`
- Phase 11 (`beeping-web`) — already consumes WASM artifact

## Merge style

Merge commit (non-squash) — matches the prior pattern set by PR #13
("Merge pull request #13 from beeping-io/develop") so the per-task
commit history stays visible on `main` for `release-please` to scan.

## Test plan

- [x] All 12 commits already CI-green on `develop` (each landed via its own PR)
- [x] Last two PRs (#24 BEE-2221, #25 BEE-2223) workflow-dispatch validated end-to-end with `gh workflow run release.yml` from their milestone branches
- [ ] After merge: `release-please.yml` opens version-bump PR → review the auto-generated CHANGELOG → merge → tag `v0.7.0` pushed → `release.yml` runs the full matrix and publishes artifacts (Android x3 + iOS XCFramework + macOS + Linux x2 + Windows x2 + WASM + cosign keyless sigs + SBOM CycloneDX + SLSA L3 provenance)
- [ ] Once `v0.7.0` is published: smoke-verify one artifact each side (e.g. `cosign verify-blob` the Android arm64-v8a tarball + `dwarfdump` the iOS xcframework) before kicking off Phase 8 BEE-65