### PR TITLE
chore(milestone): close Phase 1 — beeping-core (scheduler API, supply chain, robustness)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1057,15 +1057,36 @@ jobs:
           cd artifacts
           for f in *.tar.zst *.zip; do
             [ -f "$f" ] || continue
-            cosign sign-blob --yes --output-signature "$f.sig" "$f"
+            cosign sign-blob --yes --bundle "$f.cosign.bundle" "$f"
           done
 
       - name: Sign SBOM (cosign keyless)
         run: |
           cd artifacts
           cosign sign-blob --yes \
-            --output-signature beeping-core-sbom.cdx.json.sig \
+            --bundle beeping-core-sbom.cdx.json.cosign.bundle \
             beeping-core-sbom.cdx.json
+
+      - name: Verify bundles (smoke test)
+        run: |
+          cd artifacts
+          fail=0
+          for f in *.tar.zst *.zip beeping-core-sbom.cdx.json; do
+            [ -f "$f" ] || continue
+            if [ ! -f "$f.cosign.bundle" ]; then
+              echo "::error::missing $f.cosign.bundle"
+              fail=1
+              continue
+            fi
+            echo "::group::verify $f"
+            cosign verify-blob \
+              --bundle "$f.cosign.bundle" \
+              --certificate-identity-regexp '^https://github\.com/beeping-io/beeping-core/\.github/workflows/release\.yml@refs/tags/.*' \
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+              "$f" || fail=1
+            echo "::endgroup::"
+          done
+          exit $fail
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -1076,6 +1097,6 @@ jobs:
           files: |
             artifacts/*.tar.zst
             artifacts/*.zip
-            artifacts/*.sig
+            artifacts/*.cosign.bundle
             artifacts/beeping-core-sbom.cdx.json
             artifacts/SHA256SUMS.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
     tests/ConcurrencyTests.cpp
     tests/SchedulerTest.cpp
     tests/LoggerTest.cpp
+    tests/CodecGuardTest.cpp
   )
   if(BEEPING_BUILD_CLI)
     list(APPEND BEEPING_TEST_SOURCES tests/CLIIntegrationTest.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,11 @@ add_library(BeepingCore ${BEEPING_CORE_SOURCES})
 # Android JNI loads the library via System.loadLibrary("beepingcore") which
 # resolves to libbeepingcore.so. Force the output name to lowercase only on
 # Android so other platforms keep libBeepingCore.{a,so,dylib,dll} unchanged.
+# Also link against the NDK `log` library so spdlog's android_sink can call
+# __android_log_print() without an unresolved symbol at runtime.
 if(ANDROID)
   set_target_properties(BeepingCore PROPERTIES OUTPUT_NAME "beepingcore")
+  target_link_libraries(BeepingCore PRIVATE log)
 endif()
 
 target_include_directories(BeepingCore PUBLIC
@@ -210,6 +213,7 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
     tests/RoundTripTests.cpp
     tests/ConcurrencyTests.cpp
     tests/SchedulerTest.cpp
+    tests/LoggerTest.cpp
   )
   if(BEEPING_BUILD_CLI)
     list(APPEND BEEPING_TEST_SOURCES tests/CLIIntegrationTest.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(BEEPING_CORE_SOURCES
   src/DecoderNonAudibleMultiTone.cpp
   src/DecoderAllMultiTone.cpp
   src/Globals.cpp
+  src/Scheduler.cpp
   src/SpectralAnalysis.cpp
   src/ReedSolomon.cpp
 )
@@ -208,6 +209,7 @@ if(BUILD_TESTING AND NOT EMSCRIPTEN)
     tests/UnitTests.cpp
     tests/RoundTripTests.cpp
     tests/ConcurrencyTests.cpp
+    tests/SchedulerTest.cpp
   )
   if(BEEPING_BUILD_CLI)
     list(APPEND BEEPING_TEST_SOURCES tests/CLIIntegrationTest.cpp)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,68 @@ mono or stereo (downmixed to mono).
 
 Full docs: [`docs/cli.md`](docs/cli.md).
 
+## Time-scheduled encoding
+
+`beeping-core` exposes three C-API entry points that turn a short payload
+into a series of beeps spread across `duration` seconds. Each beep's payload
+is `code + base32(round(timestamp_seconds))`, so a decoder can recover its
+position within the schedule.
+
+```c
+#include <BeepingCoreLib_api.h>
+
+void* core = BEEPING_Create();
+BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core);
+
+// 1) Query the required output buffer size (samples)
+int32_t requiredSamples = BEEPING_GetScheduleBufferSize(/*duration=*/10.0f, core);
+
+// 2) (Optional) Inspect the schedule timestamps in seconds
+double timestamps[16];
+int32_t count = 0;
+BEEPING_ComputeBeepSchedule(/*duration*/ 10.0f, /*startTime*/ 0.0f,
+                            /*interval*/ 2.3f, timestamps, 16, &count);
+// count == 4, timestamps == {0.0, 2.3, 4.6, 6.9}
+
+// 3) Render the audio
+float* pcm = (float*)malloc(requiredSamples * sizeof(float));
+int32_t written = 0;
+BEEPING_EncodeWithSchedule("abcde", 5, /*type*/ 0, NULL, 0,
+                           /*duration*/ 10.0f, /*startTime*/ 0.0f,
+                           /*interval*/ 2.3f, /*beepGainDb*/ -3.0f,
+                           pcm, requiredSamples, &written, core);
+
+// pcm now holds `written` mono float samples at 44100 Hz, ready to play
+// or to dump into a WAV.
+
+free(pcm);
+BEEPING_Destroy(core);
+```
+
+Constraints: `duration` and `interval` must be `>= 2.3` (the minimum beep
+window), `startTime >= 0`, `startTime + 2.3 <= duration`. `beepGainDb` is
+clamped to `[-60, +12]`.
+
+On the **decode side**, a single captured beep yields the full payload
+(`code + base32(ts)`). Split it via the matching parser so SDK wrappers
+don't reimplement the convention:
+
+```c
+// After BEEPING_DecodeAudioBuffer(...) signals -3 (word decoded):
+char code[16] = {};
+int32_t codeLen = 0;
+int32_t tsSec = 0;
+int32_t rc = BEEPING_GetDecodedScheduledPayload(
+    code, sizeof(code), &codeLen, &tsSec, core);
+if (rc > 0) {
+  // code  == "abcde"
+  // tsSec ==  4   (i.e. the captured beep is the one at t=4.6s, rounded)
+}
+```
+
+`BEEPING_ParseScheduledPayload` is also exposed for parsing payloads
+obtained from elsewhere (e.g. log lines, network frames).
+
 ## Releases & verification
 
 Pre-built binaries for macOS, Linux, Android, iOS and WASM are published on

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -19,7 +19,7 @@
 Each release also includes:
 
 - `SHA256SUMS.txt` — integrity checksums
-- `<artifact>.sig` — cosign keyless signature
+- `<artifact>.cosign.bundle` — cosign keyless bundle (cert + sig + Rekor entry)
 
 ## Verify integrity
 
@@ -36,9 +36,9 @@ shasum -a 256 -c SHA256SUMS.txt --ignore-missing
 
 ```bash
 cosign verify-blob \
+  --bundle beeping-core-macos-universal.tar.zst.cosign.bundle \
   --certificate-identity-regexp "https://github.com/beeping-io/beeping-core/.github/workflows/release.yml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature beeping-core-macos-universal.tar.zst.sig \
   beeping-core-macos-universal.tar.zst
 ```
 

--- a/docs/conan.md
+++ b/docs/conan.md
@@ -186,9 +186,9 @@ All published binaries are signed with **cosign keyless** and carry
 
 ```bash
 cosign verify-blob \
+  --bundle beeping-core-macos-universal.tar.zst.cosign.bundle \
   --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature beeping-core-macos-universal.tar.zst.sig \
   beeping-core-macos-universal.tar.zst
 ```
 

--- a/docs/setup/releases.md
+++ b/docs/setup/releases.md
@@ -6,7 +6,7 @@ on, and how to recover when something breaks.
 
 ## TL;DR
 
-```
+```text
 develop  →  PR (merge commit)  →  main
                                    │
                                    ▼
@@ -100,11 +100,13 @@ token, so the workflow chain was suppressed.
 2. Check the run logs of `release-please.yml` for `releaseCreated` /
    `tagName` outputs and confirm the action is using the app token.
 3. **Manual recovery:**
+
    ```bash
    git fetch --tags origin
    git push origin --delete vX.Y.Z   # remove the tag pushed by GITHUB_TOKEN
    git push origin vX.Y.Z            # re-push from your local; fires release.yml
    ```
+
 4. After recovery, fix the workflow so it does not happen again.
 
 ### Symptom: release-please targets the wrong branch

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -10,9 +10,9 @@ Each release includes:
 | Artifact | Purpose |
 |---|---|
 | `beeping-core-<target>.tar.zst` | Compiled binary for the target platform |
-| `beeping-core-<target>.tar.zst.sig` | Cosign keyless signature |
+| `beeping-core-<target>.tar.zst.cosign.bundle` | Cosign keyless bundle (cert + sig + Rekor entry) |
 | `beeping-core-sbom.cdx.json` | CycloneDX Software Bill of Materials |
-| `beeping-core-sbom.cdx.json.sig` | Cosign signature for the SBOM |
+| `beeping-core-sbom.cdx.json.cosign.bundle` | Cosign keyless bundle for the SBOM |
 | `beeping-core.intoto.jsonl` | SLSA L3 provenance (one file per release) |
 | `SHA256SUMS.txt` | Integrity checksums for every artifact |
 
@@ -61,19 +61,20 @@ chmod +x cosign-linux-amd64 && sudo mv cosign-linux-amd64 /usr/local/bin/cosign
 ### Verify a binary
 
 ```bash
-curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.cosign.bundle
 
 cosign verify-blob \
+  --bundle $ARTIFACT.cosign.bundle \
   --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature $ARTIFACT.sig \
   $ARTIFACT
 
 # Expected: Verified OK
 ```
 
-The signature is tied to the exact GitHub Actions workflow that produced
-the binary. There are no long-lived signing keys — cosign uses a short-lived
+The bundle embeds the signing certificate and the Rekor transparency-log
+entry, so this single file is everything a downstream consumer needs to
+verify. There are no long-lived signing keys — cosign uses a short-lived
 OIDC token from GitHub Actions.
 
 ### Verify the SBOM
@@ -82,9 +83,9 @@ Same flow, with the SBOM file:
 
 ```bash
 cosign verify-blob \
+  --bundle beeping-core-sbom.cdx.json.cosign.bundle \
   --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature beeping-core-sbom.cdx.json.sig \
   beeping-core-sbom.cdx.json
 ```
 
@@ -173,22 +174,22 @@ RELEASE="${1:-v1.0.0}"
 ARTIFACT="${2:-beeping-core-macos-universal.tar.zst}"
 BASE="https://github.com/beeping-io/beeping-core/releases/download/$RELEASE"
 
-echo "→ Downloading artifact, signature, checksums, provenance, SBOM"
+echo "→ Downloading artifact, bundle, checksums, provenance, SBOM"
 curl -sLO "$BASE/$ARTIFACT"
-curl -sLO "$BASE/$ARTIFACT.sig"
+curl -sLO "$BASE/$ARTIFACT.cosign.bundle"
 curl -sLO "$BASE/SHA256SUMS.txt"
 curl -sLO "$BASE/beeping-core.intoto.jsonl"
 curl -sLO "$BASE/beeping-core-sbom.cdx.json"
-curl -sLO "$BASE/beeping-core-sbom.cdx.json.sig"
+curl -sLO "$BASE/beeping-core-sbom.cdx.json.cosign.bundle"
 
 echo "→ 1/3 SHA256 integrity"
 shasum -a 256 -c SHA256SUMS.txt --ignore-missing
 
 echo "→ 2/3 Cosign signature"
 cosign verify-blob \
+  --bundle "$ARTIFACT.cosign.bundle" \
   --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature "$ARTIFACT.sig" \
   "$ARTIFACT"
 
 echo "→ 3/3 SLSA provenance"
@@ -218,13 +219,13 @@ Verify locally with `lipo` (bundled with Xcode) and `plutil`:
 RELEASE=v1.0.0
 ARTIFACT=beeping-core-ios-xcframework.tar.zst
 curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
-curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.cosign.bundle
 
 # (Recommended) cosign verify first — same flow as section 2
 cosign verify-blob \
+  --bundle $ARTIFACT.cosign.bundle \
   --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature $ARTIFACT.sig \
   $ARTIFACT
 
 # Extract + inspect
@@ -281,13 +282,13 @@ with `-Wl,-z,max-page-size=16384`, but you can re-confirm it locally with
 ABI=arm64-v8a   # or armeabi-v7a, x86_64
 ARTIFACT=beeping-core-android-$ABI.tar.zst
 curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
-curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.sig
+curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT.cosign.bundle
 
 # 2. (Recommended) verify cosign signature first — same flow as section 2
 cosign verify-blob \
+  --bundle $ARTIFACT.cosign.bundle \
   --certificate-identity-regexp "^https://github.com/beeping-io/beeping-core/\\.github/workflows/release\\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature $ARTIFACT.sig \
   $ARTIFACT
 
 # 3. Extract and inspect ELF program headers

--- a/include/BeepingCoreLib_api.h
+++ b/include/BeepingCoreLib_api.h
@@ -300,12 +300,26 @@ BEEPING_DLLEXPORT int32_t BEEPING_DecodeAudioBuffer(float* audioBuffer,
 /**
  * @brief Retrieve the last decoded string.
  *
+ * Safe to call at any point — if no complete word has been decoded yet
+ * the function returns 0 and writes a NUL byte at `stringDecoded[0]`.
+ * (Older versions could SIGSEGV here; see BEE-2228.) Callers that drive
+ * decoding via BEEPING_DecodeAudioBuffer should still typically wait for
+ * a `-3` return code (DECODE_COMPLETE) before calling this method.
+ *
+ * Wire format: when data is available, the decoder writes 9 chars in the
+ * `[0-9a-v]` base-32 alphabet — the 5-char user payload followed by a
+ * 4-char trailer (timestamp tag for scheduler-encoded streams, or zero
+ * padding otherwise). Callers that only want the user payload should
+ * truncate to the first 5 chars; callers using
+ * BEEPING_EncodeWithSchedule() can split via
+ * BEEPING_ParseScheduledPayload() instead.
+ *
  * @param[out] stringDecoded Buffer for the decoded characters (caller
  *        provides — recommended size 30).
  * @param beepingObject Handle from BEEPING_Create().
- * @return 0 if no data available, positive with length on valid data,
- *         negative with length magnitude if the data failed integrity
- *         checks.
+ * @return 0 if no data available, positive with length (typically 9) on
+ *         valid data, negative with length magnitude if the data failed
+ *         integrity checks.
  */
 BEEPING_DLLEXPORT int32_t BEEPING_GetDecodedData(char* stringDecoded,
                                                  void* beepingObject);

--- a/include/BeepingCoreLib_api.h
+++ b/include/BeepingCoreLib_api.h
@@ -108,6 +108,29 @@ BEEPING_DLLEXPORT int32_t BEEPING_Configure(int mode, float samplingRate,
                                             void* beepingObject);
 
 /**
+ * @brief Override the log file path used by the library.
+ *
+ * Must be called *before* BEEPING_Create() to take effect. The library
+ * writes logs to a rotating file at this path; if the path cannot be
+ * opened the library falls back to a null sink (no logs) rather than
+ * crashing.
+ *
+ * @param absolutePath Absolute path to the log file. Pass `nullptr` to
+ *        reset to the default (`logs/beeping.log` relative to cwd).
+ * @return 0 on success; -1 if the logger was already initialized (call
+ *         is ignored); -2 if the argument is empty.
+ *
+ * Notes:
+ * - On Android, this is a no-op and returns 0 — the library always writes
+ *   to logcat (tag `BeepingCore`), so a writable filesystem is not
+ *   required.
+ * - On every other platform, if the configured path cannot be opened the
+ *   library logs are silently dropped (with a one-time warning to stderr)
+ *   instead of crashing the host process.
+ */
+BEEPING_DLLEXPORT int32_t BEEPING_SetLogPath(const char* absolutePath);
+
+/**
  * @brief Install a custom audio signature to mix with encoded output.
  *
  * The signature is mixed on top of the tones during playback, useful to

--- a/include/BeepingCoreLib_api.h
+++ b/include/BeepingCoreLib_api.h
@@ -169,6 +169,94 @@ BEEPING_DLLEXPORT int32_t BEEPING_ResetEncodedAudioBuffer(void* beepingObject);
 
 ///@}
 
+/** @name Time-scheduled encoding */
+///@{
+
+/**
+ * @brief Compute the timestamps (in seconds) at which beeps should fire
+ *        within `duration`.
+ *
+ * Use this for custom mixing loops, UI preview of the schedule, or any
+ * wrapper that wants to drive the encoder manually.
+ *
+ * @param duration       Total duration in seconds. Must be >= 2.3.
+ * @param startTime      Offset of the first beep in seconds. Must be >= 0
+ *                       and `startTime + 2.3 <= duration`.
+ * @param interval       Seconds between successive beeps. Must be > 0.
+ * @param[out] outTimestamps Caller-allocated array of `maxTimestamps`
+ *                       doubles. May be `nullptr` only when
+ *                       `maxTimestamps == 0` (size-query mode).
+ * @param maxTimestamps  Capacity of `outTimestamps`. Pass 0 to query the
+ *                       count without writing.
+ * @param[out] outCount  Number of beeps that fit in the schedule. Pass
+ *                       `nullptr` to skip. If `maxTimestamps < outCount`,
+ *                       only the first `maxTimestamps` are written and the
+ *                       caller can detect the truncation via this value.
+ * @return 0 on success; -1 if `outTimestamps` is null with
+ *         `maxTimestamps > 0`; -2 on invalid params.
+ */
+BEEPING_DLLEXPORT int32_t BEEPING_ComputeBeepSchedule(
+    float duration, float startTime, float interval,
+    double* outTimestamps, int32_t maxTimestamps,
+    int32_t* outCount);
+
+/**
+ * @brief Required output buffer size (in float samples) for
+ *        BEEPING_EncodeWithSchedule at the currently-configured sample rate.
+ *
+ * @param duration       Total duration in seconds (must be > 0).
+ * @param beepingObject  Handle from BEEPING_Create(), already Configure()d.
+ * @return `floor(duration * sampleRate)`, or negative on error
+ *         (`-1` if `beepingObject` is null, `-2` for invalid params).
+ */
+BEEPING_DLLEXPORT int32_t BEEPING_GetScheduleBufferSize(
+    float duration, void* beepingObject);
+
+/**
+ * @brief Encode `code` repeated as multiple beeps scheduled across
+ *        `duration` seconds.
+ *
+ * Each beep's payload is `code` concatenated with the rounded timestamp of
+ * the beep in seconds, encoded as 4-char zero-padded base-32 (alphabet
+ * `[0-9a-v]`). The decoder side can recover the beep's position within the
+ * schedule from this trailing tag.
+ *
+ * The caller-allocated `outBuffer` is filled directly; silence segments are
+ * written as zeros. No internal accumulation — the caller does not need to
+ * drain via BEEPING_GetEncodedAudioBuffer afterwards.
+ *
+ * @param code           Payload (typical: 5-char base-32 [0-9a-v] key).
+ * @param codeSize       Length of `code` in bytes.
+ * @param type           0 = pure tones, 1 = tones + R2D2, 2 = melody mode.
+ * @param melody         Melody payload (only used when `type == 2`).
+ * @param melodySize     Length of `melody` (0 for type 0 or 1).
+ * @param duration       Total duration in seconds (>= 2.3).
+ * @param startTime      Offset of first beep in seconds (>= 0).
+ * @param interval       Seconds between beeps (> 0).
+ * @param beepGainDb     Beep volume in dB, clamped internally to [-60, +12].
+ * @param[out] outBuffer Caller-allocated float array of `maxSamples` floats.
+ * @param maxSamples     Capacity of `outBuffer`. Use
+ *                       BEEPING_GetScheduleBufferSize() to size it.
+ * @param[out] outSamplesWritten On success: actual sample count written
+ *                       (`floor(duration * sampleRate)`). On a
+ *                       buffer-too-small error: the *required* size, so the
+ *                       caller can resize and retry. Pass `nullptr` to skip.
+ * @param beepingObject  Handle from BEEPING_Create(), already Configure()d.
+ * @return 0 on success; -1 if `outBuffer` is too small (with
+ *         `outSamplesWritten` carrying the required size); -2 on invalid
+ *         params; -3 if the encoder is not configured.
+ */
+BEEPING_DLLEXPORT int32_t BEEPING_EncodeWithSchedule(
+    const char* code, int32_t codeSize,
+    int32_t type, const char* melody, int32_t melodySize,
+    float duration, float startTime, float interval,
+    float beepGainDb,
+    float* outBuffer, int32_t maxSamples,
+    int32_t* outSamplesWritten,
+    void* beepingObject);
+
+///@}
+
 /** @name Decoding */
 ///@{
 
@@ -198,6 +286,56 @@ BEEPING_DLLEXPORT int32_t BEEPING_DecodeAudioBuffer(float* audioBuffer,
  */
 BEEPING_DLLEXPORT int32_t BEEPING_GetDecodedData(char* stringDecoded,
                                                  void* beepingObject);
+
+/**
+ * @brief Split a scheduler-formatted payload into its `code` prefix and
+ *        rounded-seconds timestamp suffix.
+ *
+ * Use this on any payload — including ones obtained outside this library —
+ * whose format follows `code + 4-char zero-padded base-32 timestamp`, the
+ * layout emitted by BEEPING_EncodeWithSchedule().
+ *
+ * @param payload         Raw payload bytes.
+ * @param payloadSize     Length of `payload`. Must be >= 5 (1 code char
+ *                        minimum + 4 timestamp chars).
+ * @param[out] outCode    Caller-allocated buffer for the code prefix
+ *                        (NUL-terminated). May be `nullptr` if only the
+ *                        timestamp is needed.
+ * @param maxCodeSize     Capacity of `outCode` including the NUL.
+ * @param[out] outCodeSize Length of the code prefix without NUL (==
+ *                        `payloadSize - 4`). Pass `nullptr` to skip.
+ * @param[out] outTimestampSec Rounded timestamp in seconds. Pass `nullptr`
+ *                        to skip.
+ * @return 0 on success; -1 if `outCode != nullptr` and `maxCodeSize` is too
+ *         small (must hold `payloadSize - 4 + 1` bytes); -2 if the trailing
+ *         4 chars are not valid base-32 or the payload is shorter than 5
+ *         bytes.
+ */
+BEEPING_DLLEXPORT int32_t BEEPING_ParseScheduledPayload(
+    const char* payload, int32_t payloadSize,
+    char* outCode, int32_t maxCodeSize, int32_t* outCodeSize,
+    int32_t* outTimestampSec);
+
+/**
+ * @brief Convenience wrapper that calls BEEPING_GetDecodedData() and splits
+ *        the result via BEEPING_ParseScheduledPayload() in a single step.
+ *
+ * @param[out] outCode    Caller-allocated buffer for the code prefix
+ *                        (NUL-terminated). Recommended size: 30.
+ * @param maxCodeSize     Capacity of `outCode` including the NUL.
+ * @param[out] outCodeSize Length of the code prefix without NUL.
+ *                        Pass `nullptr` to skip.
+ * @param[out] outTimestampSec Rounded timestamp in seconds. Pass `nullptr`
+ *                        to skip.
+ * @param beepingObject   Handle from BEEPING_Create().
+ * @return Length of full decoded payload on success (positive); 0 if no
+ *         decoded data; negative-with-magnitude on integrity failure
+ *         (same convention as BEEPING_GetDecodedData); -10 if the split
+ *         step failed (payload < 5 chars or invalid base-32 trailer).
+ */
+BEEPING_DLLEXPORT int32_t BEEPING_GetDecodedScheduledPayload(
+    char* outCode, int32_t maxCodeSize, int32_t* outCodeSize,
+    int32_t* outTimestampSec, void* beepingObject);
 
 ///@}
 

--- a/include/BeepingDebug.h
+++ b/include/BeepingDebug.h
@@ -14,7 +14,13 @@
 namespace BEEPING {
 
 // Initialize the beeping logger (safe to call multiple times).
-// Creates a rotating file logger in logs/ with JSON pattern.
+//
+// On Android the sink writes to logcat (tag "BeepingCore") and is always
+// available. On every other platform the sink is a rotating file at the
+// path set by setLogPath() (default "logs/beeping.log" relative to cwd);
+// if that path cannot be opened the logger falls back to a null sink so
+// the host process never crashes due to an unwritable working directory.
+//
 // Reads BEEPING_LOG_LEVEL env var (trace/debug/info/warn/error, default: warn).
 void initBeepingLogger();
 
@@ -23,6 +29,12 @@ void shutdownBeepingLogger();
 
 // Ensure logger is initialized before use
 void ensureBeepingLogger();
+
+// Override the log file path used on non-Android targets. Must be called
+// before initBeepingLogger() / BEEPING_Create() — otherwise it is ignored
+// and returns -1. Pass nullptr to reset to the default. Returns -2 if the
+// argument is empty. On Android this is a no-op and returns 0.
+int setLogPath(const char* absolutePath);
 
 }  // namespace BEEPING
 

--- a/include/Scheduler.h
+++ b/include/Scheduler.h
@@ -1,0 +1,63 @@
+/**
+ * @file Scheduler.h
+ * @brief Internal C++ helpers backing the time-scheduled encoding C API.
+ *
+ * Public consumers should use the C functions declared in BeepingCoreLib_api.h
+ * (BEEPING_ComputeBeepSchedule, BEEPING_EncodeWithSchedule). This header is
+ * an implementation detail exposed only because all BeepingCore C++ headers
+ * live under `include/` for build-tree convenience.
+ *
+ * @copyright Copyright (C) Beeping, LLC. Apache-2.0.
+ */
+
+#ifndef BEEPING_SCHEDULER_H
+#define BEEPING_SCHEDULER_H
+
+#include <string>
+#include <vector>
+
+namespace BEEPING {
+
+/// Minimum duration of one beep window in seconds. The encoder emits
+/// approximately this much audio per encoded payload at 44.1 kHz.
+inline constexpr float kMinBeepWindow = 2.3f;
+
+/// Compute how many beeps fit in `duration` seconds at `interval` cadence
+/// starting at `startTime`. Returns 0 when no beep fits (duration shorter
+/// than the minimum window, startTime offsets past `duration - 2.3`, or
+/// non-positive interval).
+int computeBeepCount(float duration, float startTime, float interval);
+
+/// Compute the timestamps (seconds, monotonically increasing) at which each
+/// beep should fire. Empty when no beep fits.
+std::vector<double> computeBeepSchedule(float duration, float startTime, float interval);
+
+/// Convert a non-negative integer to base-32 using the [0-9a-v] alphabet.
+/// Used internally by BEEPING_EncodeWithSchedule to embed the rounded
+/// timestamp of each scheduled beep into its payload, so a decoder can
+/// recover the beep's position within the schedule.
+std::string toBase32(int value);
+
+/// Parse a base-32 string back to a non-negative integer. Returns -1 if
+/// the string contains any character outside the [0-9a-v] alphabet.
+int fromBase32(const char* s, int len);
+
+/// Split a scheduler-formatted payload (`code` + 4-char zero-padded base-32
+/// timestamp) into its parts.
+///
+/// @param payload         Pointer to decoded payload chars.
+/// @param payloadSize     Length of payload in bytes.
+/// @param[out] outCode    Pointer where the code prefix start will be
+///                        written. Points into `payload` — NOT a copy.
+/// @param[out] outCodeSize Length of the code prefix (payloadSize - 4).
+/// @param[out] outTimestampSec Decoded timestamp in seconds.
+/// @return true on success, false if payloadSize < 5 (need at least 1 code
+///         char + 4 timestamp chars), or if the trailing 4 chars are not
+///         valid base-32.
+bool parseScheduledPayload(const char* payload, int payloadSize,
+                           const char** outCode, int* outCodeSize,
+                           int* outTimestampSec);
+
+}  // namespace BEEPING
+
+#endif  // BEEPING_SCHEDULER_H

--- a/src/BeepingCoreLib_api.cpp
+++ b/src/BeepingCoreLib_api.cpp
@@ -7,14 +7,17 @@
 #include <EncoderAudibleMultiTone.h>
 #include <EncoderNonAudibleMultiTone.h>
 #include <Globals.h>
+#include <Scheduler.h>
 #include <stdio.h>
 #include <string.h>
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <ctime>
 #include <iostream>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -318,4 +321,179 @@ extern "C"
   float result = beeping->mDecoder->GetDecodingEndFreq();
   BTRACE("BEEPING_GetDecodingEndFreq -> {:.1f}", result);
   return result;
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif  //__cplusplus
+    int32_t BEEPING_ComputeBeepSchedule(float duration, float startTime,
+                                        float interval, double* outTimestamps,
+                                        int32_t maxTimestamps,
+                                        int32_t* outCount) {
+  BTRACE("BEEPING_ComputeBeepSchedule d={:.3f} s={:.3f} i={:.3f} max={}",
+         duration, startTime, interval, maxTimestamps);
+
+  if (duration < BEEPING::kMinBeepWindow || interval <= 0.0f ||
+      startTime < 0.0f ||
+      (startTime + BEEPING::kMinBeepWindow) > duration + 1e-6f) {
+    BERROR(
+        "BEEPING_ComputeBeepSchedule -> -2 (invalid params: d={:.3f} s={:.3f} "
+        "i={:.3f})",
+        duration, startTime, interval);
+    return -2;
+  }
+  if (maxTimestamps > 0 && outTimestamps == nullptr) {
+    BERROR("BEEPING_ComputeBeepSchedule -> -1 (null outTimestamps)");
+    return -1;
+  }
+
+  auto schedule = BEEPING::computeBeepSchedule(duration, startTime, interval);
+  const int32_t total = static_cast<int32_t>(schedule.size());
+  const int32_t toWrite = std::min(total, maxTimestamps);
+  for (int32_t i = 0; i < toWrite; ++i) {
+    outTimestamps[i] = schedule[static_cast<size_t>(i)];
+  }
+  if (outCount) *outCount = total;
+  BTRACE("BEEPING_ComputeBeepSchedule -> 0 (count={} written={})", total,
+         toWrite);
+  return 0;
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif  //__cplusplus
+    int32_t BEEPING_GetScheduleBufferSize(float duration, void* beepingObject) {
+  if (!beepingObject) return -1;
+  BeepingContext* beeping = static_cast<BeepingContext*>(beepingObject);
+  if (duration <= 0.0f || beeping->mSampleRate <= 0.0f) return -2;
+  return static_cast<int32_t>(std::floor(duration * beeping->mSampleRate));
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif  //__cplusplus
+    int32_t BEEPING_EncodeWithSchedule(
+        const char* code, int32_t codeSize, int32_t type, const char* melody,
+        int32_t melodySize, float duration, float startTime, float interval,
+        float beepGainDb, float* outBuffer, int32_t maxSamples,
+        int32_t* outSamplesWritten, void* beepingObject) {
+  if (!beepingObject) return -3;
+  BeepingContext* beeping = static_cast<BeepingContext*>(beepingObject);
+  if (!beeping->mEncoder) return -3;
+  if (!code || codeSize <= 0) return -2;
+  if (duration < BEEPING::kMinBeepWindow || interval <= 0.0f ||
+      startTime < 0.0f ||
+      (startTime + BEEPING::kMinBeepWindow) > duration + 1e-6f) {
+    return -2;
+  }
+
+  BINFO(
+      "BEEPING_EncodeWithSchedule code=\"{}\" d={:.3f} s={:.3f} i={:.3f} "
+      "gainDb={:.2f}",
+      std::string_view(code, codeSize), duration, startTime, interval,
+      beepGainDb);
+
+  const float sampleRate = beeping->mSampleRate;
+  const int32_t requiredSamples =
+      static_cast<int32_t>(std::floor(duration * sampleRate));
+
+  if (!outBuffer || maxSamples < requiredSamples) {
+    if (outSamplesWritten) *outSamplesWritten = requiredSamples;
+    return -1;
+  }
+
+  auto schedule = BEEPING::computeBeepSchedule(duration, startTime, interval);
+
+  std::fill(outBuffer, outBuffer + requiredSamples, 0.0f);
+
+  const float clampedDb = std::clamp(beepGainDb, -60.0f, 12.0f);
+  const float gainLinear = std::pow(10.0f, clampedDb / 20.0f);
+
+  const int bufferSize = beeping->mBufferSize > 0 ? beeping->mBufferSize : 128;
+  std::vector<float> tmpBuf(static_cast<size_t>(bufferSize));
+
+  for (double ts : schedule) {
+    const int tsSec = static_cast<int>(ts + 0.5);
+    std::string tsB32 = BEEPING::toBase32(tsSec);
+    while (tsB32.size() < 4) tsB32.insert(tsB32.begin(), '0');
+
+    std::string payload(code, static_cast<size_t>(codeSize));
+    payload += tsB32;
+
+    beeping->mEncoder->EncodeDataToAudioBuffer(
+        payload.c_str(), type, static_cast<int>(payload.size()), melody,
+        melodySize);
+
+    const int32_t offset = static_cast<int32_t>(std::floor(ts * sampleRate));
+    int32_t writePos = offset;
+    while (writePos < requiredSamples) {
+      const int32_t n = beeping->mEncoder->GetEncodedAudioBuffer(tmpBuf.data());
+      if (n <= 0) break;
+      const int32_t remaining = requiredSamples - writePos;
+      const int32_t toCopy = std::min(n, remaining);
+      for (int32_t k = 0; k < toCopy; ++k) {
+        outBuffer[writePos + k] = gainLinear * tmpBuf[static_cast<size_t>(k)];
+      }
+      writePos += n;
+      if (n < bufferSize) break;
+    }
+    beeping->mEncoder->ResetEncodedAudioBuffer();
+  }
+
+  if (outSamplesWritten) *outSamplesWritten = requiredSamples;
+  BTRACE("BEEPING_EncodeWithSchedule -> 0 (written={} beeps={})",
+         requiredSamples, schedule.size());
+  return 0;
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif  //__cplusplus
+    int32_t BEEPING_ParseScheduledPayload(const char* payload,
+                                          int32_t payloadSize, char* outCode,
+                                          int32_t maxCodeSize,
+                                          int32_t* outCodeSize,
+                                          int32_t* outTimestampSec) {
+  const char* codeStart = nullptr;
+  int codeSize = 0;
+  int tsSec = 0;
+  if (!BEEPING::parseScheduledPayload(payload, payloadSize, &codeStart,
+                                      &codeSize, &tsSec)) {
+    return -2;
+  }
+  if (outCode) {
+    if (maxCodeSize <= codeSize) return -1;
+    std::memcpy(outCode, codeStart, static_cast<size_t>(codeSize));
+    outCode[codeSize] = '\0';
+  }
+  if (outCodeSize) *outCodeSize = codeSize;
+  if (outTimestampSec) *outTimestampSec = tsSec;
+  return 0;
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif  //__cplusplus
+    int32_t BEEPING_GetDecodedScheduledPayload(char* outCode,
+                                               int32_t maxCodeSize,
+                                               int32_t* outCodeSize,
+                                               int32_t* outTimestampSec,
+                                               void* beepingObject) {
+  if (!beepingObject) return 0;
+  BeepingContext* beeping = static_cast<BeepingContext*>(beepingObject);
+  if (!beeping->mDecoder) return 0;
+
+  // Use a stack buffer large enough for the existing GetDecodedData
+  // recommendation (30 chars) plus headroom.
+  char raw[64] = {};
+  int32_t rc = beeping->mDecoder->GetDecodedData(raw);
+  if (rc == 0) return 0;
+
+  const int32_t payloadLen = std::abs(rc);
+  int32_t splitRc = BEEPING_ParseScheduledPayload(
+      raw, payloadLen, outCode, maxCodeSize, outCodeSize, outTimestampSec);
+  if (splitRc != 0) return -10;
+
+  BTRACE("BEEPING_GetDecodedScheduledPayload rc={} -> {}", rc, payloadLen);
+  return rc;
 }

--- a/src/BeepingCoreLib_api.cpp
+++ b/src/BeepingCoreLib_api.cpp
@@ -159,6 +159,13 @@ extern "C"
 #ifdef __cplusplus
 extern "C"
 #endif  //__cplusplus
+    int32_t BEEPING_SetLogPath(const char* absolutePath) {
+  return BEEPING::setLogPath(absolutePath);
+}
+
+#ifdef __cplusplus
+extern "C"
+#endif  //__cplusplus
     int32_t BEEPING_SetAudioSignature(int32_t samplesSize,
                                       const float* samplesBuffer,
                                       void* beepingObject) {

--- a/src/BeepingDebug.cpp
+++ b/src/BeepingDebug.cpp
@@ -1,8 +1,15 @@
 #include <BeepingDebug.h>
-#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
 
+#ifdef __ANDROID__
+#include <spdlog/sinks/android_sink.h>
+#else
+#include <spdlog/sinks/null_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#endif
+
 #include <atomic>
+#include <cstdio>
 #include <cstdlib>
 #include <mutex>
 #include <string>
@@ -17,13 +24,32 @@
 
 namespace BEEPING {
 
+static constexpr const char* kDefaultLogPath = "logs/beeping.log";
 static std::mutex g_init_mutex;
 static std::atomic<bool> g_initialized{false};
 static std::atomic<int> g_session_count{0};
+static std::string g_log_path = kDefaultLogPath;
 
 void ensureBeepingLogger() {
   if (g_initialized.load(std::memory_order_acquire)) return;
   initBeepingLogger();
+}
+
+int setLogPath(const char* absolutePath) {
+#ifdef __ANDROID__
+  (void)absolutePath;
+  return 0;
+#else
+  std::lock_guard<std::mutex> lk(g_init_mutex);
+  if (g_initialized.load(std::memory_order_relaxed)) return -1;
+  if (absolutePath == nullptr) {
+    g_log_path = kDefaultLogPath;
+    return 0;
+  }
+  if (*absolutePath == '\0') return -2;
+  g_log_path = absolutePath;
+  return 0;
+#endif
 }
 
 void initBeepingLogger() {
@@ -33,18 +59,43 @@ void initBeepingLogger() {
     return;
   }
 
-  // Create logs directory
-  beeping_mkdir("logs");
+  std::shared_ptr<spdlog::sinks::sink> sink;
+  std::string sink_kind;
 
-  // Rotating file sink: 5MB max, 10 files
-  auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-      "logs/beeping.log", 5 * 1024 * 1024, 10);
+#ifdef __ANDROID__
+  // Logcat sink — no filesystem dependency, immune to a read-only cwd.
+  sink = std::make_shared<spdlog::sinks::android_sink_mt>("BeepingCore");
+  sink_kind = "android(logcat)";
+#else
+  // Best-effort: if the path is the legacy default, try to create the
+  // companion `logs/` directory. Failure is fine; the open below will
+  // surface any real problem.
+  if (g_log_path == kDefaultLogPath) {
+    beeping_mkdir("logs");
+  }
 
-  // JSON pattern
-  file_sink->set_pattern(
+  try {
+    sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+        g_log_path, 5 * 1024 * 1024, 10);
+    sink_kind = "file:" + g_log_path;
+  } catch (const spdlog::spdlog_ex& ex) {
+    // Unwritable target — drop logs silently instead of crashing the host
+    // process. One-time warning to stderr so the misconfiguration is
+    // discoverable in dev.
+    std::fprintf(
+        stderr,
+        "[beeping-core] log path %s unwritable (%s); logs disabled. Call "
+        "BEEPING_SetLogPath() before BEEPING_Create() to redirect.\n",
+        g_log_path.c_str(), ex.what());
+    sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+    sink_kind = "null(unwritable)";
+  }
+#endif
+
+  sink->set_pattern(
       R"({"ts":"%Y-%m-%dT%H:%M:%S.%e","level":"%l","msg":"%v"})");
 
-  auto logger = std::make_shared<spdlog::logger>("beeping", file_sink);
+  auto logger = std::make_shared<spdlog::logger>("beeping", sink);
 
   // Read log level from env var BEEPING_LOG_LEVEL
   const char* env_level = std::getenv("BEEPING_LOG_LEVEL");
@@ -69,7 +120,8 @@ void initBeepingLogger() {
   g_initialized.store(true, std::memory_order_release);
   g_session_count.store(1);
 
-  spdlog::info("BeepingCore logger initialized (level={})", level_str);
+  spdlog::info("BeepingCore logger initialized (sink={} level={})", sink_kind,
+               level_str);
 }
 
 void shutdownBeepingLogger() {

--- a/src/DecoderAllMultiTone.cpp
+++ b/src/DecoderAllMultiTone.cpp
@@ -311,6 +311,13 @@ int DecoderAllMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
 }
 
 int DecoderAllMultiTone::GetDecodedData(char* stringDecoded) {
+  // BEE-2228: guard against polling before DECODE_COMPLETE (same fix as
+  // DecoderNonAudibleMultiTone).
+  if (static_cast<int>(mDecodedValues.size()) < Globals::numTotalTokens) {
+    if (stringDecoded) stringDecoded[0] = '\0';
+    return 0;
+  }
+
   int messageOk = 1;
   // init ReedSolomon functions (set message length)
 

--- a/src/DecoderAudibleMultiTone.cpp
+++ b/src/DecoderAudibleMultiTone.cpp
@@ -193,6 +193,13 @@ int DecoderAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
 }
 
 int DecoderAudibleMultiTone::GetDecodedData(char* stringDecoded) {
+  // BEE-2228: guard against polling before DECODE_COMPLETE (same fix as
+  // DecoderNonAudibleMultiTone).
+  if (static_cast<int>(mDecodedValues.size()) < Globals::numTotalTokens) {
+    if (stringDecoded) stringDecoded[0] = '\0';
+    return 0;
+  }
+
   int messageOk = 1;
   // init ReedSolomon functions (set message length)
 

--- a/src/DecoderNonAudibleMultiTone.cpp
+++ b/src/DecoderNonAudibleMultiTone.cpp
@@ -199,6 +199,15 @@ int DecoderNonAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer,
 }
 
 int DecoderNonAudibleMultiTone::GetDecodedData(char* stringDecoded) {
+  // BEE-2228: bail out before touching mDecodedValues / mReedSolomon if no
+  // complete word has been decoded yet. Callers that poll this method
+  // before DECODE_COMPLETE used to hit SIGSEGV in ReedSolomon::SetCode
+  // dereferencing an empty vector.
+  if (static_cast<int>(mDecodedValues.size()) < Globals::numTotalTokens) {
+    if (stringDecoded) stringDecoded[0] = '\0';
+    return 0;
+  }
+
   int messageOk = 1;
   // init ReedSolomon functions (set message length)
 

--- a/src/ReedSolomon.cpp
+++ b/src/ReedSolomon.cpp
@@ -404,6 +404,14 @@ void ReedSolomon::GetCode(std::vector<int>& code) {
 
 // decoding received code
 void ReedSolomon::SetCode(const std::vector<int> code) {
+  // BEE-2228: defensive guard. The legacy condition below allows entry to
+  // the shortened-code branch even when `code` is empty or too short, and
+  // then dereferences code[msg_len + i] unconditionally — SIGSEGV. Refuse
+  // to enter the branch unless the caller has supplied at least
+  // `msg_len + (nn - kk)` elements, which is what the loops below assume.
+  if (static_cast<int>(code.size()) < msg_len + (nn - kk)) {
+    return;
+  }
   if ((static_cast<int>(code.size()) < kk) && (msg_len < kk)) {
     // copy received error code digits (8)
     for (int i = 0; i < (nn - kk); ++i) recd[i] = code[msg_len + i];

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -1,0 +1,75 @@
+#include "Scheduler.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace BEEPING {
+
+int computeBeepCount(float duration, float startTime, float interval) {
+  if (duration < kMinBeepWindow) return 0;
+  if (startTime < 0.0f) return 0;
+  if (interval <= 0.0f) return 0;
+  if ((startTime + kMinBeepWindow) > duration) return 0;
+
+  const float remaining = duration - startTime - kMinBeepWindow;
+  const int extra = static_cast<int>(std::floor((remaining + 1e-6f) / interval));
+  return 1 + std::max(extra, 0);
+}
+
+std::vector<double> computeBeepSchedule(float duration, float startTime, float interval) {
+  std::vector<double> times;
+  const int count = computeBeepCount(duration, startTime, interval);
+  times.reserve(static_cast<size_t>(count));
+  double t = static_cast<double>(startTime);
+  while (static_cast<int>(times.size()) < count &&
+         (t + kMinBeepWindow) <= static_cast<double>(duration) + 1e-6) {
+    times.push_back(t);
+    t += static_cast<double>(interval);
+  }
+  return times;
+}
+
+static constexpr char kBase32Digits[] = "0123456789abcdefghijklmnopqrstuv";
+
+std::string toBase32(int value) {
+  if (value <= 0) return "0";
+  std::string result;
+  while (value > 0) {
+    result.insert(result.begin(), kBase32Digits[value % 32]);
+    value /= 32;
+  }
+  return result;
+}
+
+int fromBase32(const char* s, int len) {
+  if (!s || len <= 0) return -1;
+  int result = 0;
+  for (int i = 0; i < len; ++i) {
+    const char c = s[i];
+    int digit = -1;
+    for (int j = 0; j < 32; ++j) {
+      if (c == kBase32Digits[j]) {
+        digit = j;
+        break;
+      }
+    }
+    if (digit < 0) return -1;
+    result = result * 32 + digit;
+  }
+  return result;
+}
+
+bool parseScheduledPayload(const char* payload, int payloadSize,
+                           const char** outCode, int* outCodeSize,
+                           int* outTimestampSec) {
+  if (!payload || payloadSize < 5) return false;
+  const int tsStart = payloadSize - 4;
+  const int ts = fromBase32(payload + tsStart, 4);
+  if (ts < 0) return false;
+  if (outCode) *outCode = payload;
+  if (outCodeSize) *outCodeSize = tsStart;
+  if (outTimestampSec) *outTimestampSec = ts;
+  return true;
+}
+
+}  // namespace BEEPING

--- a/tests/CodecGuardTest.cpp
+++ b/tests/CodecGuardTest.cpp
@@ -1,0 +1,135 @@
+// CodecGuardTest.cpp — BEE-2228 guard tests.
+//
+// (1) BEEPING_GetDecodedData must be safe to call before DECODE_COMPLETE
+//     (was SIGSEGV in ReedSolomon::SetCode dereferencing an empty vector).
+// (2) The codec wire format always emits 9 chars (5 data + 4 trailer);
+//     this test pins the contract so a future refactor doesn't silently
+//     break the scheduler payload split.
+
+#include <BeepingCoreLib_api.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct DecodeResult {
+  int decoded = -1;
+  int rc = 0;
+  std::string out;
+};
+
+DecodeResult roundTrip(int mode, float sr, const char* payload, int bufSize) {
+  void* enc = BEEPING_Create();
+  BEEPING_Configure(mode, sr, bufSize, enc);
+  int total = BEEPING_EncodeDataToAudioBuffer(
+      payload, static_cast<int>(std::strlen(payload)), 0, nullptr, 0, enc);
+  std::vector<float> audio;
+  audio.reserve(total);
+  std::vector<float> buf(bufSize);
+  while (true) {
+    int n = BEEPING_GetEncodedAudioBuffer(buf.data(), enc);
+    if (n <= 0) break;
+    audio.insert(audio.end(), buf.begin(), buf.begin() + n);
+    if (n < bufSize) break;
+  }
+  BEEPING_Destroy(enc);
+
+  void* dec = BEEPING_Create();
+  BEEPING_Configure(mode, sr, bufSize, dec);
+  int decoded = -1;
+  for (size_t i = 0; i < audio.size(); i += bufSize) {
+    int chunk = std::min(bufSize, static_cast<int>(audio.size() - i));
+    decoded = BEEPING_DecodeAudioBuffer(audio.data() + i, chunk, dec);
+    if (decoded == -3) break;
+  }
+  if (decoded != -3) {
+    std::vector<float> silence(bufSize, 0.0f);
+    for (int flush = 0; flush < 200; ++flush) {
+      decoded = BEEPING_DecodeAudioBuffer(silence.data(), bufSize, dec);
+      if (decoded == -3) break;
+    }
+  }
+  DecodeResult r{decoded, 0, {}};
+  if (decoded == -3) {
+    char tmp[64] = {};
+    r.rc = BEEPING_GetDecodedData(tmp, dec);
+    r.out = std::string(tmp, static_cast<size_t>(std::abs(r.rc)));
+  }
+  BEEPING_Destroy(dec);
+  return r;
+}
+
+}  // namespace
+
+// ===========================================================================
+// (1) Guard: GetDecodedData before DECODE_COMPLETE must not crash
+// ===========================================================================
+
+TEST_CASE(
+    "BEE-2228 guard: GetDecodedData on a fresh decoder returns 0 and does "
+    "not crash",
+    "[bee-2228][guard]") {
+  void* core = BEEPING_Create();
+  REQUIRE(core != nullptr);
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 1024, core) == 0);
+  char buf[64] = {};
+  // Before the BEE-2228 fix this dereferenced ReedSolomon::recd over an
+  // empty mDecodedValues vector — SIGSEGV.
+  REQUIRE(BEEPING_GetDecodedData(buf, core) == 0);
+  REQUIRE(buf[0] == '\0');
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE(
+    "BEE-2228 guard: GetDecodedData survives all three decoder backends",
+    "[bee-2228][guard]") {
+  for (int mode :
+       {BEEPING_MODE_AUDIBLE, BEEPING_MODE_INAUDIBLE, BEEPING_MODE_ALL}) {
+    void* core = BEEPING_Create();
+    REQUIRE(BEEPING_Configure(mode, 44100.0f, 1024, core) == 0);
+    char buf[64] = {};
+    INFO("mode=" << mode);
+    REQUIRE(BEEPING_GetDecodedData(buf, core) == 0);
+    BEEPING_Destroy(core);
+  }
+}
+
+// ===========================================================================
+// (2) Contract: decoded output is the 9-char payload-plus-trailer string
+// ===========================================================================
+
+TEST_CASE(
+    "BEE-2228 contract: 9-char input round-trips exactly at the canonical "
+    "bufSize=1024",
+    "[bee-2228][contract]") {
+  // This is the canonical happy-path: 9-char payload (5 data + 4 trailer)
+  // round-trips byte-for-byte through encode→decode in-process. This
+  // already worked before BEE-2228 — pin it so a future scheduler refactor
+  // does not silently break it.
+  auto r = roundTrip(BEEPING_MODE_INAUDIBLE, 44100.0f, "abcde0002", 1024);
+  INFO("decoded=" << r.decoded << " rc=" << r.rc << " out=\"" << r.out
+                  << "\"");
+  REQUIRE(r.decoded == -3);
+  REQUIRE(r.rc == 9);
+  REQUIRE(r.out == "abcde0002");
+}
+
+TEST_CASE(
+    "BEE-2228 contract: 5-char input is zero-padded to the 9-char wire "
+    "format on decode",
+    "[bee-2228][contract]") {
+  // Documenting the protocol: passing a 5-char input to
+  // BEEPING_EncodeDataToAudioBuffer encodes 5 data tokens, and the decoder
+  // returns the same 5 chars followed by 4 trailing zeros. Callers that
+  // want just the user payload must truncate to the first 5 chars.
+  auto r = roundTrip(BEEPING_MODE_INAUDIBLE, 44100.0f, "abc12", 1024);
+  INFO("decoded=" << r.decoded << " rc=" << r.rc << " out=\"" << r.out
+                  << "\"");
+  REQUIRE(r.decoded == -3);
+  REQUIRE(r.rc == 9);
+  REQUIRE(r.out == "abc120000");
+}

--- a/tests/LoggerTest.cpp
+++ b/tests/LoggerTest.cpp
@@ -14,26 +14,27 @@
 #include <BeepingCoreLib_api.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <string>
-#include <sys/stat.h>
-#include <unistd.h>
 
 namespace {
 
 bool fileExists(const std::string& path) {
-  struct stat st;
-  return ::stat(path.c_str(), &st) == 0;
+  std::error_code ec;
+  return std::filesystem::exists(path, ec);
 }
 
 std::string uniqueTempLogPath() {
-  const char* tmpdir = std::getenv("TMPDIR");
-  if (!tmpdir) tmpdir = "/tmp";
-  char buf[256] = {};
-  std::snprintf(buf, sizeof(buf), "%s/beeping-test-%d-%ld.log", tmpdir,
-                static_cast<int>(getpid()), static_cast<long>(rand()));
-  return buf;
+  static std::atomic<int> counter{0};
+  const auto tmpdir = std::filesystem::temp_directory_path();
+  const int n = counter.fetch_add(1);
+  char name[64] = {};
+  std::snprintf(name, sizeof(name), "beeping-test-%d-%d.log",
+                static_cast<int>(std::rand()), n);
+  return (tmpdir / name).string();
 }
 
 }  // namespace

--- a/tests/LoggerTest.cpp
+++ b/tests/LoggerTest.cpp
@@ -1,0 +1,107 @@
+// LoggerTest.cpp — Catch2 v3 tests for BEEPING_SetLogPath and the
+// non-crashing fallback when the configured log path is unwritable.
+//
+// The runtime invariant we protect is: BEEPING_Create() must never crash
+// the host process even if the working directory is read-only or the
+// configured log path is invalid. Before BEE-2227, spdlog would throw
+// spdlog_ex when opening a relative `logs/beeping.log` under Android's
+// `/` cwd; the exception was uncaught and the runtime called terminate().
+//
+// Tests are written to be order-independent: many other test cases also
+// call BEEPING_Create() and may leave the logger initialized, so we never
+// assume a clean global state when our test starts.
+
+#include <BeepingCoreLib_api.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+
+bool fileExists(const std::string& path) {
+  struct stat st;
+  return ::stat(path.c_str(), &st) == 0;
+}
+
+std::string uniqueTempLogPath() {
+  const char* tmpdir = std::getenv("TMPDIR");
+  if (!tmpdir) tmpdir = "/tmp";
+  char buf[256] = {};
+  std::snprintf(buf, sizeof(buf), "%s/beeping-test-%d-%ld.log", tmpdir,
+                static_cast<int>(getpid()), static_cast<long>(rand()));
+  return buf;
+}
+
+}  // namespace
+
+TEST_CASE("SetLogPath: rejects empty string", "[logger]") {
+  // Either logger is uninitialized (-> -2 because of empty arg) or it is
+  // already initialized (-> -1 because it is locked). In neither case
+  // should the empty string be silently accepted (which would later cause
+  // spdlog to throw with cryptic errors).
+  int rc = BEEPING_SetLogPath("");
+  REQUIRE((rc == -2 || rc == -1));
+}
+
+TEST_CASE("SetLogPath: returns -1 once the logger is initialized",
+          "[logger]") {
+  // Force the logger to be initialized for this test scope.
+  void* core = BEEPING_Create();
+  REQUIRE(core != nullptr);
+
+  // Once initialized, any rebind attempt must be rejected.
+  REQUIRE(BEEPING_SetLogPath("/tmp/foo.log") == -1);
+  REQUIRE(BEEPING_SetLogPath(nullptr) == -1);
+
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("BEEPING_Create does not crash with an unwritable log path",
+          "[logger]") {
+  // This is the regression test for BEE-2227. If our test is the first to
+  // initialize the logger we can actually steer it to the bad path and
+  // exercise the fallback. If a prior test already initialized the
+  // logger, SetLogPath returns -1 and we cannot reroute — the assertion
+  // becomes "Create still does not crash with whatever path was set
+  // before", which is exactly the user-visible contract we care about.
+  int rc = BEEPING_SetLogPath("/this/path/should/not/exist/beeping.log");
+  REQUIRE((rc == 0 || rc == -1));
+
+  void* core = BEEPING_Create();
+  REQUIRE(core != nullptr);
+
+  // A real codepath that calls into the logger via the BTRACE macros.
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("SetLogPath: writes to a custom absolute path when uninitialized",
+          "[logger]") {
+  const std::string path = uniqueTempLogPath();
+  int rc = BEEPING_SetLogPath(path.c_str());
+  if (rc == -1) {
+    // Another test already initialized the logger. Nothing more we can
+    // assert here without test isolation — leave as a smoke check.
+    SUCCEED("logger already initialized; skipping path-write assertion");
+    return;
+  }
+  REQUIRE(rc == 0);
+
+  void* core = BEEPING_Create();
+  REQUIRE(core != nullptr);
+  BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core);
+  BEEPING_Destroy(core);
+
+  INFO("custom log path = " << path);
+  REQUIRE(fileExists(path));
+  std::remove(path.c_str());
+
+  // Reset to default so we do not leak this path into subsequent tests
+  // if they happen to run while the logger has been torn down.
+  BEEPING_SetLogPath(nullptr);
+}

--- a/tests/SchedulerTest.cpp
+++ b/tests/SchedulerTest.cpp
@@ -1,0 +1,420 @@
+// SchedulerTest.cpp — Catch2 v3 tests for the time-scheduled encoding C API
+// (BEEPING_ComputeBeepSchedule, BEEPING_GetScheduleBufferSize,
+// BEEPING_EncodeWithSchedule).
+
+#include <BeepingCoreLib_api.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+
+// ===========================================================================
+// BEEPING_ComputeBeepSchedule
+// ===========================================================================
+
+TEST_CASE("ComputeBeepSchedule: minimum duration yields a single beep",
+          "[scheduler]") {
+  double timestamps[16] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(2.3f, 0.0f, 2.3f, timestamps, 16,
+                                           &count);
+  REQUIRE(rc == 0);
+  REQUIRE(count == 1);
+  REQUIRE_THAT(timestamps[0], WithinAbs(0.0, 1e-6));
+}
+
+TEST_CASE("ComputeBeepSchedule: 10s @ 2.3s interval yields 4 beeps",
+          "[scheduler]") {
+  double timestamps[16] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(10.0f, 0.0f, 2.3f, timestamps, 16,
+                                           &count);
+  REQUIRE(rc == 0);
+  REQUIRE(count == 4);
+  REQUIRE_THAT(timestamps[0], WithinAbs(0.0, 1e-6));
+  REQUIRE_THAT(timestamps[1], WithinAbs(2.3, 1e-3));
+  REQUIRE_THAT(timestamps[2], WithinAbs(4.6, 1e-3));
+  REQUIRE_THAT(timestamps[3], WithinAbs(6.9, 1e-3));
+}
+
+TEST_CASE("ComputeBeepSchedule: duration below kMinBeepWindow rejected",
+          "[scheduler]") {
+  double timestamps[4] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(2.0f, 0.0f, 2.3f, timestamps, 4,
+                                           &count);
+  REQUIRE(rc == -2);
+}
+
+TEST_CASE("ComputeBeepSchedule: startTime offset reduces count",
+          "[scheduler]") {
+  double timestamps[4] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(5.0f, 1.0f, 2.3f, timestamps, 4,
+                                           &count);
+  REQUIRE(rc == 0);
+  REQUIRE(count == 1);
+  REQUIRE_THAT(timestamps[0], WithinAbs(1.0, 1e-6));
+}
+
+TEST_CASE("ComputeBeepSchedule: negative interval rejected", "[scheduler]") {
+  double timestamps[4] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(10.0f, 0.0f, -1.0f, timestamps, 4,
+                                           &count);
+  REQUIRE(rc == -2);
+}
+
+TEST_CASE(
+    "ComputeBeepSchedule: negative startTime rejected",
+    "[scheduler]") {
+  double timestamps[4] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(10.0f, -0.1f, 2.3f, timestamps, 4,
+                                           &count);
+  REQUIRE(rc == -2);
+}
+
+TEST_CASE("ComputeBeepSchedule: startTime past duration rejected",
+          "[scheduler]") {
+  double timestamps[4] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(5.0f, 4.0f, 2.3f, timestamps, 4,
+                                           &count);
+  REQUIRE(rc == -2);
+}
+
+TEST_CASE(
+    "ComputeBeepSchedule: size-query mode returns count without writing",
+    "[scheduler]") {
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(10.0f, 0.0f, 2.3f, nullptr, 0,
+                                           &count);
+  REQUIRE(rc == 0);
+  REQUIRE(count == 4);
+}
+
+TEST_CASE(
+    "ComputeBeepSchedule: null buffer with maxTimestamps > 0 rejected",
+    "[scheduler]") {
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(10.0f, 0.0f, 2.3f, nullptr, 4,
+                                           &count);
+  REQUIRE(rc == -1);
+}
+
+TEST_CASE(
+    "ComputeBeepSchedule: truncation surfaced through outCount",
+    "[scheduler]") {
+  double timestamps[2] = {};
+  int32_t count = -1;
+  int32_t rc = BEEPING_ComputeBeepSchedule(10.0f, 0.0f, 2.3f, timestamps, 2,
+                                           &count);
+  REQUIRE(rc == 0);
+  REQUIRE(count == 4);
+  REQUIRE_THAT(timestamps[0], WithinAbs(0.0, 1e-6));
+  REQUIRE_THAT(timestamps[1], WithinAbs(2.3, 1e-3));
+}
+
+TEST_CASE("ComputeBeepSchedule: closed-form parity across param sweeps",
+          "[scheduler][property]") {
+  struct Case {
+    float duration;
+    float startTime;
+    float interval;
+    int expected;
+  };
+  const Case cases[] = {
+      {2.3f, 0.0f, 2.3f, 1},
+      {4.6f, 0.0f, 2.3f, 2},
+      {10.0f, 0.0f, 2.3f, 4},
+      {30.0f, 0.0f, 5.0f, 6},
+      {5.0f, 1.0f, 2.3f, 1},
+      {5.0f, 0.5f, 2.3f, 1},
+      {100.0f, 0.0f, 10.0f, 10},
+      {7.0f, 2.0f, 2.3f, 2},
+  };
+  for (const auto& c : cases) {
+    int32_t count = -1;
+    int32_t rc = BEEPING_ComputeBeepSchedule(c.duration, c.startTime,
+                                             c.interval, nullptr, 0, &count);
+    INFO("d=" << c.duration << " s=" << c.startTime << " i=" << c.interval);
+    REQUIRE(rc == 0);
+    REQUIRE(count == c.expected);
+  }
+}
+
+// ===========================================================================
+// BEEPING_GetScheduleBufferSize
+// ===========================================================================
+
+TEST_CASE("GetScheduleBufferSize: returns duration * sampleRate",
+          "[scheduler]") {
+  void* core = BEEPING_Create();
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+  REQUIRE(BEEPING_GetScheduleBufferSize(10.0f, core) == 441000);
+  REQUIRE(BEEPING_GetScheduleBufferSize(2.3f, core) ==
+          static_cast<int32_t>(std::floor(2.3f * 44100.0f)));
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("GetScheduleBufferSize: null handle returns -1", "[scheduler]") {
+  REQUIRE(BEEPING_GetScheduleBufferSize(10.0f, nullptr) == -1);
+}
+
+TEST_CASE("GetScheduleBufferSize: zero duration returns -2", "[scheduler]") {
+  void* core = BEEPING_Create();
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+  REQUIRE(BEEPING_GetScheduleBufferSize(0.0f, core) == -2);
+  BEEPING_Destroy(core);
+}
+
+// ===========================================================================
+// BEEPING_EncodeWithSchedule
+// ===========================================================================
+
+TEST_CASE("EncodeWithSchedule: 10s @ 44.1k produces 441000 non-silent samples",
+          "[scheduler][encode]") {
+  void* core = BEEPING_Create();
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+
+  const float duration = 10.0f;
+  const int32_t required = BEEPING_GetScheduleBufferSize(duration, core);
+  REQUIRE(required == 441000);
+
+  std::vector<float> buf(static_cast<size_t>(required), 0.0f);
+  int32_t written = -1;
+  int32_t rc = BEEPING_EncodeWithSchedule("abcde", 5, 0, nullptr, 0, duration,
+                                          0.0f, 2.3f, -3.0f, buf.data(),
+                                          required, &written, core);
+  REQUIRE(rc == 0);
+  REQUIRE(written == required);
+
+  bool hasNonZero = false;
+  for (float s : buf) {
+    if (std::fabs(s) > 1e-9f) {
+      hasNonZero = true;
+      break;
+    }
+  }
+  REQUIRE(hasNonZero);
+
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("EncodeWithSchedule: buffer too small returns required size",
+          "[scheduler][encode]") {
+  void* core = BEEPING_Create();
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+
+  std::vector<float> tooSmall(100, 0.0f);
+  int32_t written = -1;
+  int32_t rc = BEEPING_EncodeWithSchedule(
+      "abcde", 5, 0, nullptr, 0, 10.0f, 0.0f, 2.3f, 0.0f, tooSmall.data(),
+      static_cast<int32_t>(tooSmall.size()), &written, core);
+  REQUIRE(rc == -1);
+  REQUIRE(written == 441000);
+
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("EncodeWithSchedule: unconfigured core returns -3",
+          "[scheduler][encode]") {
+  void* core = BEEPING_Create();
+  std::vector<float> buf(1024, 0.0f);
+  int32_t written = -1;
+  int32_t rc = BEEPING_EncodeWithSchedule(
+      "abcde", 5, 0, nullptr, 0, 10.0f, 0.0f, 2.3f, 0.0f, buf.data(),
+      static_cast<int32_t>(buf.size()), &written, core);
+  REQUIRE(rc == -3);
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("EncodeWithSchedule: null code rejected", "[scheduler][encode]") {
+  void* core = BEEPING_Create();
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+  std::vector<float> buf(441000, 0.0f);
+  int32_t written = -1;
+  int32_t rc = BEEPING_EncodeWithSchedule(
+      nullptr, 0, 0, nullptr, 0, 10.0f, 0.0f, 2.3f, 0.0f, buf.data(),
+      static_cast<int32_t>(buf.size()), &written, core);
+  REQUIRE(rc == -2);
+  BEEPING_Destroy(core);
+}
+
+// ===========================================================================
+// BEEPING_ParseScheduledPayload
+// ===========================================================================
+
+TEST_CASE("ParseScheduledPayload: splits code + base32 timestamp",
+          "[scheduler][parse]") {
+  // Payload that EncodeWithSchedule emits for code="abcde", ts=2s (rounded).
+  // toBase32(2) = "2", zero-padded to 4 chars => "0002".
+  const char payload[] = "abcde0002";
+  char codeBuf[16] = {};
+  int32_t codeSize = -1;
+  int32_t ts = -1;
+  int32_t rc =
+      BEEPING_ParseScheduledPayload(payload, 9, codeBuf, 16, &codeSize, &ts);
+  REQUIRE(rc == 0);
+  REQUIRE(codeSize == 5);
+  REQUIRE(std::string(codeBuf) == "abcde");
+  REQUIRE(ts == 2);
+}
+
+TEST_CASE("ParseScheduledPayload: timestamp via base32 [a-v]",
+          "[scheduler][parse]") {
+  // toBase32(10) = "a" (since alphabet is 0-9a-v), zero-padded => "000a".
+  const char payload[] = "abcde000a";
+  char codeBuf[16] = {};
+  int32_t codeSize = -1;
+  int32_t ts = -1;
+  int32_t rc =
+      BEEPING_ParseScheduledPayload(payload, 9, codeBuf, 16, &codeSize, &ts);
+  REQUIRE(rc == 0);
+  REQUIRE(ts == 10);
+}
+
+TEST_CASE("ParseScheduledPayload: large timestamp", "[scheduler][parse]") {
+  // Pick a timestamp > 32 to exercise multi-digit base32. ts=2025 in base32:
+  // 2025 / 32 = 63 r 9; 63 / 32 = 1 r 31; 1 / 32 = 0 r 1. So digits are
+  // [1, 31, 9] = "1v9" -> 4-char padded => "01v9".
+  const char payload[] = "abcde01v9";
+  int32_t ts = -1;
+  int32_t rc = BEEPING_ParseScheduledPayload(payload, 9, nullptr, 0, nullptr,
+                                             &ts);
+  REQUIRE(rc == 0);
+  REQUIRE(ts == 2025);
+}
+
+TEST_CASE("ParseScheduledPayload: payload too short rejected",
+          "[scheduler][parse]") {
+  const char payload[] = "abcd";  // only 4 chars
+  int32_t rc =
+      BEEPING_ParseScheduledPayload(payload, 4, nullptr, 0, nullptr, nullptr);
+  REQUIRE(rc == -2);
+}
+
+TEST_CASE("ParseScheduledPayload: invalid base32 in timestamp rejected",
+          "[scheduler][parse]") {
+  // 'z' is not in [0-9a-v].
+  const char payload[] = "abcde00z2";
+  int32_t rc =
+      BEEPING_ParseScheduledPayload(payload, 9, nullptr, 0, nullptr, nullptr);
+  REQUIRE(rc == -2);
+}
+
+TEST_CASE("ParseScheduledPayload: code buffer too small rejected",
+          "[scheduler][parse]") {
+  const char payload[] = "abcde0002";
+  char codeBuf[4] = {};  // need 5 + 1 NUL = 6 minimum
+  int32_t rc =
+      BEEPING_ParseScheduledPayload(payload, 9, codeBuf, 4, nullptr, nullptr);
+  REQUIRE(rc == -1);
+}
+
+TEST_CASE("ParseScheduledPayload: timestamp-only extraction without code",
+          "[scheduler][parse]") {
+  const char payload[] = "xyz123450005";  // 12 chars: code='xyz12345' ts=5
+  int32_t codeSize = -1;
+  int32_t ts = -1;
+  int32_t rc = BEEPING_ParseScheduledPayload(payload, 12, nullptr, 0,
+                                             &codeSize, &ts);
+  REQUIRE(rc == 0);
+  REQUIRE(codeSize == 8);
+  REQUIRE(ts == 5);
+}
+
+TEST_CASE("ParseScheduledPayload: round-trip via toBase32 alphabet",
+          "[scheduler][parse]") {
+  // For every ts in {0, 1, 5, 31, 32, 100, 1023, 32767}, build a payload
+  // emitted by EncodeWithSchedule (`code` + zero-padded base32) and verify
+  // the parser recovers the original ts.
+  const int candidates[] = {0, 1, 5, 31, 32, 100, 1023, 32767};
+  for (int expected : candidates) {
+    // Mimic the encoder's zero-padding logic.
+    auto toB32 = [](int v) {
+      static const char* alpha = "0123456789abcdefghijklmnopqrstuv";
+      if (v <= 0) return std::string("0");
+      std::string r;
+      while (v > 0) {
+        r.insert(r.begin(), alpha[v % 32]);
+        v /= 32;
+      }
+      return r;
+    };
+    std::string b32 = toB32(expected);
+    while (b32.size() < 4) b32.insert(b32.begin(), '0');
+    std::string payload = std::string("abcde") + b32;
+
+    int32_t ts = -1;
+    int32_t rc = BEEPING_ParseScheduledPayload(
+        payload.c_str(), static_cast<int32_t>(payload.size()), nullptr, 0,
+        nullptr, &ts);
+    INFO("expected ts=" << expected << " b32=" << b32);
+    REQUIRE(rc == 0);
+    REQUIRE(ts == expected);
+  }
+}
+
+// ===========================================================================
+// BEEPING_GetDecodedScheduledPayload
+// ===========================================================================
+
+TEST_CASE("GetDecodedScheduledPayload: returns 0 on unconfigured core",
+          "[scheduler][parse]") {
+  void* core = BEEPING_Create();
+  char codeBuf[16] = {};
+  int32_t rc = BEEPING_GetDecodedScheduledPayload(codeBuf, 16, nullptr, nullptr,
+                                                  core);
+  REQUIRE(rc == 0);
+  BEEPING_Destroy(core);
+}
+
+TEST_CASE("GetDecodedScheduledPayload: returns 0 on null handle",
+          "[scheduler][parse]") {
+  char codeBuf[16] = {};
+  int32_t rc =
+      BEEPING_GetDecodedScheduledPayload(codeBuf, 16, nullptr, nullptr,
+                                         nullptr);
+  REQUIRE(rc == 0);
+}
+
+TEST_CASE("EncodeWithSchedule: beeps land at expected offsets",
+          "[scheduler][encode]") {
+  void* core = BEEPING_Create();
+  REQUIRE(BEEPING_Configure(BEEPING_MODE_INAUDIBLE, 44100.0f, 128, core) == 0);
+
+  const float duration = 10.0f;
+  const float interval = 2.3f;
+  const int32_t required = BEEPING_GetScheduleBufferSize(duration, core);
+  std::vector<float> buf(static_cast<size_t>(required), 0.0f);
+  int32_t written = -1;
+  int32_t rc = BEEPING_EncodeWithSchedule("abcde", 5, 0, nullptr, 0, duration,
+                                          0.0f, interval, -3.0f, buf.data(),
+                                          required, &written, core);
+  REQUIRE(rc == 0);
+
+  // We expect 4 non-silent regions, one starting near each scheduled offset.
+  const double offsets[] = {0.0, 2.3, 4.6, 6.9};
+  for (double t : offsets) {
+    const int32_t centerSample = static_cast<int32_t>(t * 44100.0) + 1000;
+    REQUIRE(centerSample < required);
+    bool foundEnergy = false;
+    for (int32_t i = std::max(0, centerSample - 200);
+         i < std::min(required, centerSample + 200); ++i) {
+      if (std::fabs(buf[static_cast<size_t>(i)]) > 1e-6f) {
+        foundEnergy = true;
+        break;
+      }
+    }
+    INFO("scheduled offset t=" << t << "s (sample " << centerSample << ")");
+    REQUIRE(foundEnergy);
+  }
+
+  BEEPING_Destroy(core);
+}


### PR DESCRIPTION
## Summary

Closes the Phase 1 — beeping-core (C++20) milestone. Five tasks merged
to the milestone branch since the last develop merge:

- **BEE-2238** — Add beep scheduler (duration/startTime/interval) to the
  public C API; unblocks BEE-2239..2247 (beepbox refactor + 7 SDKs + CLI)
- **BEE-2225** — cosign sign-blob emits `.cosign.bundle` (cert+sig+Rekor)
  instead of bare `.sig`; release smoke test added; docs updated
- **BEE-2227** — Android-aware logger sink (logcat) + non-crashing
  fallback when log path is unwritable + `BEEPING_SetLogPath` C API
- **BEE-2228** — `BEEPING_GetDecodedData` guard against pre-decode polling
  (was SIGSEGV) + 9-char wire-format documentation

BEE-30 (Conan recipe / ConanCenter publication) stays In Progress: local
work is 100% complete, only waiting on upstream maintainer review at
conan-io/conan-center-index#29997. Downstream consumers have a working
fallback via GitHub Releases binaries (BEE-29).

Closes BEE-2238, BEE-2225, BEE-2227, BEE-2228

## Test plan

- [x] Full Catch2 suite: 75 cases / 276,705 assertions
- [x] BEE-2238 scheduler subset: 29 cases / 98 assertions
- [x] BEE-2227 logger subset: 4 cases / 8 assertions
- [x] BEE-2228 guard subset: 4 cases / 16 assertions
- [ ] CI green on PR (Build & Test + sanitizers + static analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)