### PR TITLE
chore(repo): BEE-2276 add Community section + gitleaks audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,29 @@ Two supported consumption paths via Conan 2.x:
 
 Full guide with copy-paste examples: [`docs/conan.md`](docs/conan.md).
 
+## Community
+
+### Chat & support
+
+- 💬 **Discord** — [chat with the team and other developers](https://discord.gg/beeping)
+- 💼 **Slack** — coming soon (will be cross-bridged with Discord)
+- 🐛 **Issues** — [github.com/beeping-io/beeping-core/issues](https://github.com/beeping-io/beeping-core/issues) for bugs and feature requests
+
+### Follow us
+
+Social handles coming soon — see the issue tracker for status.
+
+- 🐦 X (Twitter) · 💼 LinkedIn · 📸 Instagram · 🎵 TikTok · 📺 YouTube · 🐘 Mastodon · 🦋 Bluesky
+
+### Project governance
+
+- 🛡️ **Security** — formal `SECURITY.md` disclosure policy is on the way; in the meantime, please email security at beeping dot io for vulnerability reports
+- 🤝 **Contributing** — formal `CONTRIBUTING.md` is on the way; the project uses conventional commits, semantic-release via `release-please`, and PRs against `develop`
+
+Beeping is built in the open. The library here is the C++20 foundation; SDK
+wrappers, the HTTP server and platform-native bindings live in the sibling
+repos of the [`beeping-io`](https://github.com/beeping-io) org.
+
 ## License
 
 [Apache-2.0](LICENSE)

--- a/docs/security/gitleaks-2026-05-18.md
+++ b/docs/security/gitleaks-2026-05-18.md
@@ -1,0 +1,49 @@
+# 🛡️ Secrets-leak audit · 2026-05-18
+
+> Performed as part of BEE-2276 (Phase 27 · 🧱 Make `beeping-core` public —
+> README + LICENSE audit + topics + secrets hygiene).
+
+## Tool
+
+[`gitleaks`](https://github.com/gitleaks/gitleaks) (Homebrew install, default ruleset)
+
+## Scope
+
+Working tree + full git history (`--log-opts="--all"`) at commit
+[`04f7108`](https://github.com/beeping-io/beeping-core/commit/04f7108)
+(`develop` HEAD at audit time).
+
+## Command
+
+```bash
+gitleaks detect --source . --no-banner --log-opts="--all"
+```
+
+## Result
+
+```text
+31 commits scanned.
+scanned ~1139137 bytes (1.14 MB) in 159ms
+no leaks found
+```
+
+**No leaks found.** The repo is clean to be exposed publicly (it was already
+public at the time of the audit; this report is the formal evidence).
+
+## Cadence
+
+Re-run gitleaks before any major release or whenever a new branch is
+merged that touched configuration / CI / build scripts. The repo's CI
+should pick up a `gitleaks` job in a follow-up task (out of scope here).
+
+## Verification by reviewers
+
+To reproduce locally:
+
+```bash
+brew install gitleaks  # or apt/snap/winget equivalents
+cd beeping-core
+gitleaks detect --source . --no-banner --log-opts="--all"
+```
+
+Expected output: `no leaks found`.


### PR DESCRIPTION
## Summary

- Audit cleanup of `beeping-core` ahead of the broader OSS launch (Phase 1 of the `beeping-www` milestone).
- README gains a `## Community` section with three sub-blocks: **Chat & support** (Discord live, Slack coming), **Follow us** (placeholders for X / LinkedIn / Instagram / TikTok / YouTube / Mastodon / Bluesky — tracked in BEE-2216), and **Project governance** (interim notes pending the formal `SECURITY.md` / `CONTRIBUTING.md` of BEE-2274).
- `gitleaks detect --log-opts="--all"` ran clean (31 commits, 1.14 MB, 0 leaks). Evidence committed at `docs/security/gitleaks-2026-05-18.md` with reproduction command for reviewers.

## GitHub-side metadata (live already, not in this diff)

- 🔗 **Homepage** → `https://core-docs.beeping.io`
- 🏷️ **8 topics** → `audio`, `cmake`, `conan`, `cpp20`, `cross-platform`, `data-over-sound`, `ultrasonic`, `wasm`

These were applied via `gh repo edit` and are visible on the public repo page now.

## Linear

Closes **BEE-2276** (already moved to Done after Human QA Checkpoint Fase A approval).

Cross-task impact:
- **BEE-2216** expanded in scope to launch X + LinkedIn + Instagram + TikTok + YouTube + Mastodon + Bluesky accounts (+ brand voice + post templates); follow-up PR will replace the README placeholders with real links across the 5 repos.
- **BEE-2274** will land the formal `SECURITY.md` + `CONTRIBUTING.md` + `CODE_OF_CONDUCT.md` + ADR template cross-repo, also resolving the README's interim placeholders.

## Test plan

- [x] `markdownlint README.md docs/security/gitleaks-2026-05-18.md` → 0 errors
- [x] `gitleaks detect --source . --no-banner --log-opts="--all"` → no leaks
- [x] `gh repo view beeping-io/beeping-core --json homepageUrl,repositoryTopics` confirms metadata applied
- [x] Human QA Checkpoint Fase A — founder verified topics + homepage live on incognito + approved diff
- [ ] CI: build + tests on this PR (docs-only change, no behavior impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)