### PR TITLE
fix(core): bufferSize round-trip fix + linux-musl artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,9 +431,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # Linux compat smoke matrix — verify the linux-amd64 binary actually runs
   # on multiple glibc distros before allowing the release to publish.
-  # Alpine (musl) is intentionally excluded: BEE-1729 ships glibc-only.
-  # If demand for musl arises, a separate `beeping-core-linux-amd64-musl.tar.zst`
-  # variant will be added in its own task.
+  # Alpine (musl) lives in linux-musl-x64 / linux-musl-compat-smoke below.
   # ---------------------------------------------------------------------------
   linux-compat-smoke:
     name: Linux compat (${{ matrix.image }})
@@ -574,6 +572,140 @@ jobs:
               /opt/bin/beeping-core --version
               echo '✅ ${{ matrix.image }} arm64 OK'
             "
+
+  # ---------------------------------------------------------------------------
+  # Linux musl (Alpine) — amd64
+  #
+  # Built inside an alpine:3.20 container via `docker run` (NOT a job-level
+  # `container:`, which breaks JS actions like checkout/upload-artifact: the
+  # runner's bundled Node is glibc-linked and cannot exec under musl). Static
+  # libstdc++/libgcc keeps the binary self-contained; musl libc itself is
+  # dynamically linked and present on every Alpine host. spdlog is resolved via
+  # FetchContent (same as the glibc linux-amd64 job), so the container needs git.
+  # Unblocks Alpine Docker consumers of the server-side SDKs (beeping-node,
+  # beeping-python). BEE-2288.
+  # ---------------------------------------------------------------------------
+  linux-musl-x64:
+    name: Linux musl amd64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build + install in Alpine
+        run: |
+          docker run --rm \
+            -v "$PWD:/src" \
+            -w /src \
+            alpine:3.20 \
+            sh -c '
+              set -e
+              apk add --no-cache build-base cmake git zstd linux-headers
+              cmake -B build \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBUILD_TESTING=OFF \
+                -DBEEPING_BUILD_CLI=ON \
+                -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+                -DCMAKE_INSTALL_PREFIX=install
+              cmake --build build --config Release -j"$(nproc)"
+              cmake --install build
+            '
+
+      - name: Verify musl linkage + smoke-test CLI
+        run: |
+          docker run --rm \
+            -v "$PWD:/src" \
+            -w /src \
+            alpine:3.20 \
+            sh -c '
+              set -e
+              apk add --no-cache file
+              file install/bin/beeping-core
+              ldd install/bin/beeping-core || true
+              # The binary must be musl-linked; ld-linux* is the glibc loader.
+              if ldd install/bin/beeping-core 2>&1 | grep -q "ld-linux"; then
+                echo "::error::binary is glibc-linked, expected musl"; exit 1
+              fi
+              echo "✅ musl-linked"
+              install/bin/beeping-core --help
+              install/bin/beeping-core --version
+            '
+
+      - name: Package
+        run: |
+          docker run --rm \
+            -v "$PWD:/src" \
+            -w /src \
+            alpine:3.20 \
+            sh -c '
+              set -e
+              # GNU tar (apk add tar) is required for --zstd; BusyBox tar lacks it.
+              apk add --no-cache tar zstd
+              cd install
+              tar --zstd -cf ../beeping-core-linux-amd64-musl.tar.zst .
+              cd ..
+              sha256sum beeping-core-linux-amd64-musl.tar.zst > beeping-core-linux-amd64-musl.sha256
+            '
+
+      - name: Verify CLI in tarball (Alpine)
+        run: |
+          docker run --rm \
+            -v "$PWD:/src" \
+            -w /src \
+            alpine:3.20 \
+            sh -c '
+              set -e
+              apk add --no-cache tar zstd
+              mkdir -p verify
+              tar --zstd -xf beeping-core-linux-amd64-musl.tar.zst -C verify
+              test -x verify/bin/beeping-core || { echo "❌ CLI binary missing in packaged tarball"; exit 1; }
+              verify/bin/beeping-core --help
+            '
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: beeping-core-linux-amd64-musl
+          path: |
+            beeping-core-linux-amd64-musl.tar.zst
+            beeping-core-linux-amd64-musl.sha256
+
+  # ---------------------------------------------------------------------------
+  # Linux musl compat smoke matrix — verify the musl binary actually runs on a
+  # spread of Alpine releases before allowing the release to publish. Mirrors
+  # linux-compat-smoke (glibc) but for musl hosts.
+  # ---------------------------------------------------------------------------
+  linux-musl-compat-smoke:
+    name: Linux musl compat (${{ matrix.image }})
+    needs: [linux-musl-x64]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - alpine:3.18
+          - alpine:3.19
+          - alpine:3.20
+          - alpine:edge
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: beeping-core-linux-amd64-musl
+          path: artifact
+
+      - name: Smoke test musl binary in ${{ matrix.image }}
+        run: |
+          docker run --rm \
+            -v "$PWD/artifact:/release:ro" \
+            ${{ matrix.image }} \
+            sh -c '
+              set -e
+              apk add --no-cache tar zstd
+              mkdir -p /opt/beeping
+              tar --zstd -xf /release/beeping-core-linux-amd64-musl.tar.zst -C /opt/beeping
+              /opt/beeping/bin/beeping-core --help
+              /opt/beeping/bin/beeping-core --version
+              echo "✅ ${{ matrix.image }} musl OK"
+            '
 
   # ---------------------------------------------------------------------------
   # Android NDK — arm64-v8a, armeabi-v7a, x86_64
@@ -990,7 +1122,7 @@ jobs:
   # ---------------------------------------------------------------------------
   hashes:
     name: Compute artifact hashes
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, linux-musl-x64, linux-musl-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.compute.outputs.hashes }}
@@ -1030,7 +1162,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish GitHub Release
-    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
+    needs: [macos, linux-amd64, linux-compat-smoke, linux-arm64, linux-arm64-compat-smoke, linux-musl-x64, linux-musl-compat-smoke, windows-x64, windows-arm64, android, android-smoke, ios, ios-smoke, wasm, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -8,8 +8,9 @@
 | Target | Archs | Artifact |
 |---|---|---|
 | 🍎 macOS | arm64 + x86_64 universal | `beeping-core-macos-universal.tar.zst` |
-| 🐧 Linux | amd64 | `beeping-core-linux-amd64.tar.zst` |
-| 🐧 Linux | arm64 | `beeping-core-linux-arm64.tar.zst` |
+| 🐧 Linux (glibc) | amd64 | `beeping-core-linux-amd64.tar.zst` |
+| 🐧 Linux (glibc) | arm64 | `beeping-core-linux-arm64.tar.zst` |
+| 🐧 Linux (musl / Alpine) | amd64 | `beeping-core-linux-amd64-musl.tar.zst` |
 | 🤖 Android NDK | arm64-v8a (16 KB pages, minSdk 24) | `beeping-core-android-arm64-v8a.tar.zst` |
 | 🤖 Android NDK | armeabi-v7a (16 KB pages, minSdk 24) | `beeping-core-android-armeabi-v7a.tar.zst` |
 | 🤖 Android NDK | x86_64 (16 KB pages, minSdk 24) | `beeping-core-android-x86_64.tar.zst` |

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <string.h>
 
+#include <algorithm>  // std::max
 #include <cstdio>
 #include <numeric>  //accumulate
 #include <vector>
@@ -44,7 +45,15 @@ Decoder::Decoder(const BeepingConfig& config, float samplingRate, int buffSize,
 
   mReadPosInFrameCircularBuffer = 0;
   mWritePosInFrameCircularBuffer = 0;
-  mSizeFrameCircularBuffer = mSpectralAnalysis->mWindowSize * 4;
+  // The frame buffer must hold one full input chunk (mBufferSize) plus a window
+  // of margin: DecodeAudioBuffer drains all complete windows per call, leaving
+  // < windowSize residual, then the next call writes up to mBufferSize more.
+  // Sizing only at windowSize*4 overflowed when bufferSize > windowSize (the
+  // write lapped the unread read pointer), silently corrupting the payload —
+  // BEE-2249. The windowSize*4 floor preserves the original headroom for the
+  // common bufferSize <= windowSize case.
+  mSizeFrameCircularBuffer = std::max(mSpectralAnalysis->mWindowSize * 4,
+                                      mBufferSize + mWindowSize * 2);
   mCircularBufferFloat = new float[mSizeFrameCircularBuffer];
   memset(mCircularBufferFloat, 0, mSizeFrameCircularBuffer * sizeof(float));
   mAnalBufferFloat = new float[mSpectralAnalysis->mWindowSize];

--- a/src/DecoderAllMultiTone.cpp
+++ b/src/DecoderAllMultiTone.cpp
@@ -225,8 +225,15 @@ int DecoderAllMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
   mWritePosInFrameCircularBuffer =
       (size + mWritePosInFrameCircularBuffer) % (mSizeFrameCircularBuffer);
 
-  // if enough data filled (mBufferSize), then send to decode library
-
+  // Drain every complete window available this call instead of returning on the
+  // first event. With bufferSize > windowSize a single call writes more than
+  // one window, so an early return left the surplus undrained; across calls the
+  // residual accumulated until it lapped the read pointer and corrupted the
+  // payload (BEE-2249). Draining fully keeps the residual below windowSize, so
+  // the latest non-terminal event is latched and reported, while WORD COMPLETE
+  // (-3) still returns immediately so the caller can read the word and the
+  // remaining samples persist for the next call.
+  int result = -1;
   while (getSizeFilledFrameCircularBuffer() >=
          sizeWindow) {  // copy from circularBufferFloat to sendBuffer
     for (i = 0; i < sizeWindow; i++)
@@ -268,8 +275,7 @@ int DecoderAllMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
 
 #endif  // DEBUG_OUTPUT
 
-        BTRACE("DecoderAllMultiTone::DecodeAudioBuffer -> {}", -2);
-        return -2;  //-2 means start token found
+        result = -2;  //-2 means start token found
       }
     } else if ((mDecoding > 0) &&
                (mDecoding <=
@@ -284,8 +290,7 @@ int DecoderAllMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
             "DecoderAllMultiTone::DecodeAudioBuffer token decoded idx={} "
             "char='{}' mode={}",
             ret, Globals::getCharFromIdx(ret), mDecodingMode);
-        BTRACE("DecoderAllMultiTone::DecodeAudioBuffer -> {}", ret);
-        return ret;
+        result = ret;
       }
     } else if (mDecoding >
                Globals::numMessageTokens)  // we have finished decoding a
@@ -307,7 +312,8 @@ int DecoderAllMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
     }
   }
 
-  return -1;
+  BTRACE("DecoderAllMultiTone::DecodeAudioBuffer -> {}", result);
+  return result;
 }
 
 int DecoderAllMultiTone::GetDecodedData(char* stringDecoded) {

--- a/src/DecoderAudibleMultiTone.cpp
+++ b/src/DecoderAudibleMultiTone.cpp
@@ -122,8 +122,15 @@ int DecoderAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
   mWritePosInFrameCircularBuffer =
       (size + mWritePosInFrameCircularBuffer) % (mSizeFrameCircularBuffer);
 
-  // if enough data filled (mBufferSize), then send to decode library
-
+  // Drain every complete window available this call instead of returning on the
+  // first event. With bufferSize > windowSize a single call writes more than
+  // one window, so an early return left the surplus undrained; across calls the
+  // residual accumulated until it lapped the read pointer and corrupted the
+  // payload (BEE-2249). Draining fully keeps the residual below windowSize, so
+  // the latest non-terminal event is latched and reported, while WORD COMPLETE
+  // (-3) still returns immediately so the caller can read the word and the
+  // remaining samples persist for the next call.
+  int result = -1;
   while (getSizeFilledFrameCircularBuffer() >=
          sizeWindow) {  // copy from circularBufferFloat to sendBuffer
     for (i = 0; i < sizeWindow; i++)
@@ -151,8 +158,7 @@ int DecoderAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
 
         BINFO(
             "DecoderAudibleMultiTone::DecodeAudioBuffer START TOKEN DETECTED");
-        BTRACE("DecoderAudibleMultiTone::DecodeAudioBuffer -> {}", -2);
-        return -2;  //-2 means start token found
+        result = -2;  //-2 means start token found
       }
     } else if ((mDecoding > 0) &&
                (mDecoding <=
@@ -167,8 +173,7 @@ int DecoderAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
             "DecoderAudibleMultiTone::DecodeAudioBuffer token decoded idx={} "
             "char='{}'",
             ret, Globals::getCharFromIdx(ret));
-        BTRACE("DecoderAudibleMultiTone::DecodeAudioBuffer -> {}", ret);
-        return ret;
+        result = ret;
       }
     } else if (mDecoding >
                Globals::numMessageTokens)  // we have finished decoding a
@@ -189,7 +194,8 @@ int DecoderAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer, int size) {
     }
   }
 
-  return -1;
+  BTRACE("DecoderAudibleMultiTone::DecodeAudioBuffer -> {}", result);
+  return result;
 }
 
 int DecoderAudibleMultiTone::GetDecodedData(char* stringDecoded) {

--- a/src/DecoderNonAudibleMultiTone.cpp
+++ b/src/DecoderNonAudibleMultiTone.cpp
@@ -127,8 +127,15 @@ int DecoderNonAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer,
   mWritePosInFrameCircularBuffer =
       (size + mWritePosInFrameCircularBuffer) % (mSizeFrameCircularBuffer);
 
-  // if enough data filled (mBufferSize), then send to decode library
-
+  // Drain every complete window available this call instead of returning on the
+  // first event. With bufferSize > windowSize a single call writes more than
+  // one window, so an early return left the surplus undrained; across calls the
+  // residual accumulated until it lapped the read pointer and corrupted the
+  // payload (BEE-2249). Draining fully keeps the residual below windowSize, so
+  // the latest non-terminal event is latched and reported, while WORD COMPLETE
+  // (-3) still returns immediately so the caller can read the word and the
+  // remaining samples persist for the next call.
+  int result = -1;
   while (getSizeFilledFrameCircularBuffer() >=
          sizeWindow) {  // copy from circularBufferFloat to sendBuffer
     for (i = 0; i < sizeWindow; i++)
@@ -157,8 +164,7 @@ int DecoderNonAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer,
         BINFO(
             "DecoderNonAudibleMultiTone::DecodeAudioBuffer START TOKEN "
             "DETECTED");
-        BTRACE("DecoderNonAudibleMultiTone::DecodeAudioBuffer -> {}", -2);
-        return -2;  //-2 means start token found
+        result = -2;  //-2 means start token found
       }
     } else if ((mDecoding > 0) &&
                (mDecoding <=
@@ -173,8 +179,7 @@ int DecoderNonAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer,
             "DecoderNonAudibleMultiTone::DecodeAudioBuffer token decoded "
             "idx={} char='{}'",
             ret, Globals::getCharFromIdx(ret));
-        BTRACE("DecoderNonAudibleMultiTone::DecodeAudioBuffer -> {}", ret);
-        return ret;
+        result = ret;
       }
     } else if (mDecoding >
                Globals::numMessageTokens)  // we have finished decoding a
@@ -195,7 +200,8 @@ int DecoderNonAudibleMultiTone::DecodeAudioBuffer(float* audioBuffer,
     }
   }
 
-  return -1;
+  BTRACE("DecoderNonAudibleMultiTone::DecodeAudioBuffer -> {}", result);
+  return result;
 }
 
 int DecoderNonAudibleMultiTone::GetDecodedData(char* stringDecoded) {

--- a/tests/RoundTripTests.cpp
+++ b/tests/RoundTripTests.cpp
@@ -101,7 +101,7 @@ static constexpr const char* kPayload = "123456789";
 // BEE-2249 (bufferSize > windowSize corrupted the payload).
 // ===========================================================================
 
-TEST_CASE("RoundTrip matrix (rate × mode × bufferSize)", "[roundtrip]") {
+TEST_CASE("RoundTrip matrix (rate x mode x bufferSize)", "[roundtrip]") {
   float sampleRate =
       GENERATE(22050.0f, 24000.0f, 32000.0f, 44100.0f, 48000.0f, 96000.0f);
 

--- a/tests/RoundTripTests.cpp
+++ b/tests/RoundTripTests.cpp
@@ -1,27 +1,34 @@
 // RoundTripTests.cpp — Encode-then-decode round-trip tests for beeping-core.
 //
 // These are the most critical tests: they verify the codec actually works
-// end-to-end at multiple sample rates and all 3 modes.
+// end-to-end at multiple sample rates, all 3 modes, and every supported
+// bufferSize. The bufferSize axis is the regression guard for BEE-2249, where
+// any bufferSize > windowSize corrupted the payload (the decoder's frame ring
+// buffer overflowed because it drained only up to the first event per call).
 
 #include <BeepingCoreLib_api.h>
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <cstring>
 #include <string>
 #include <vector>
 
 // ---------------------------------------------------------------------------
-// Helper: full encode → decode round-trip
+// Helper: full encode → decode round-trip at an arbitrary bufferSize.
+// Returns the decoded payload (empty string on any failure).
 // ---------------------------------------------------------------------------
 
-static bool roundTrip(int mode, float sampleRate, const char* payload) {
+static std::string roundTrip(int mode, float sampleRate, const char* payload,
+                             int bufferSize) {
   // --- Encoder ---
   void* encoder = BEEPING_Create();
-  if (!encoder) return false;
+  if (!encoder) return "";
 
-  if (BEEPING_Configure(mode, sampleRate, 1024, encoder) != 0) {
+  if (BEEPING_Configure(mode, sampleRate, bufferSize, encoder) != 0) {
     BEEPING_Destroy(encoder);
-    return false;
+    return "";
   }
 
   int payloadLen = static_cast<int>(std::strlen(payload));
@@ -29,152 +36,80 @@ static bool roundTrip(int mode, float sampleRate, const char* payload) {
                                                      nullptr, 0, encoder);
   if (totalSamples <= 0) {
     BEEPING_Destroy(encoder);
-    return false;
+    return "";
   }
 
-  // Drain all encoded audio
+  // Drain all encoded audio. The drain buffer must match bufferSize:
+  // GetEncodedAudioBuffer writes up to bufferSize samples per call.
   std::vector<float> audio;
-  audio.reserve(totalSamples);
-  std::vector<float> buf(1024);
+  audio.reserve(static_cast<size_t>(totalSamples));
+  std::vector<float> buf(static_cast<size_t>(bufferSize));
   while (true) {
     int n = BEEPING_GetEncodedAudioBuffer(buf.data(), encoder);
     if (n <= 0) break;
     audio.insert(audio.end(), buf.begin(), buf.begin() + n);
-    if (n < 1024) break;
+    if (n < bufferSize) break;
   }
   BEEPING_Destroy(encoder);
 
   // --- Decoder ---
   void* decoder = BEEPING_Create();
-  if (!decoder) return false;
+  if (!decoder) return "";
 
-  if (BEEPING_Configure(mode, sampleRate, 1024, decoder) != 0) {
+  if (BEEPING_Configure(mode, sampleRate, bufferSize, decoder) != 0) {
     BEEPING_Destroy(decoder);
-    return false;
+    return "";
   }
 
-  // Feed encoded audio to decoder in chunks
+  // Feed encoded audio to decoder in bufferSize-sized chunks.
   int decoded = -1;
-  for (size_t i = 0; i < audio.size(); i += 1024) {
-    int chunkSize = std::min(1024, static_cast<int>(audio.size() - i));
+  for (size_t i = 0; i < audio.size(); i += static_cast<size_t>(bufferSize)) {
+    int chunkSize = std::min(bufferSize, static_cast<int>(audio.size() - i));
     decoded = BEEPING_DecodeAudioBuffer(audio.data() + i, chunkSize, decoder);
     if (decoded == -3) break;  // -3 = complete word decoded
   }
 
-  // If not decoded yet, flush with silence to push remaining frames through
+  // If not decoded yet, flush with silence to push remaining frames through.
   if (decoded != -3) {
-    std::vector<float> silence(1024, 0.0f);
-    for (int flush = 0; flush < 200; ++flush) {
-      decoded = BEEPING_DecodeAudioBuffer(silence.data(), 1024, decoder);
+    std::vector<float> silence(static_cast<size_t>(bufferSize), 0.0f);
+    for (int flush = 0; flush < 400; ++flush) {
+      decoded = BEEPING_DecodeAudioBuffer(silence.data(), bufferSize, decoder);
       if (decoded == -3) break;
     }
   }
 
-  bool success = false;
+  std::string out;
   if (decoded == -3) {
     char result[64] = {0};
     int rc = BEEPING_GetDecodedData(result, decoder);
-    if (rc > 0) {
-      success = (std::string(result, rc) == std::string(payload));
-    }
+    if (rc > 0) out.assign(result, static_cast<size_t>(rc));
   }
 
   BEEPING_Destroy(decoder);
-  return success;
+  return out;
 }
 
-// ===========================================================================
-// Round-trip at 96000 Hz
-// ===========================================================================
-
-TEST_CASE("RoundTrip 96000 Hz", "[roundtrip][96000]") {
-  SECTION("Audible") {
-    REQUIRE(roundTrip(BEEPING_MODE_AUDIBLE, 96000.0f, "123456789"));
-  }
-  SECTION("Inaudible") {
-    REQUIRE(roundTrip(BEEPING_MODE_INAUDIBLE, 96000.0f, "123456789"));
-  }
-  SECTION("All") {
-    REQUIRE(roundTrip(BEEPING_MODE_ALL, 96000.0f, "123456789"));
-  }
-}
+// The codec zero-pads the payload to numWordTokens (9) characters, so a 9-char
+// payload round-trips to itself.
+static constexpr const char* kPayload = "123456789";
 
 // ===========================================================================
-// Round-trip at 48000 Hz
+// Parametric round-trip matrix: sampleRate × mode × bufferSize.
+//
+// Every combination must recover the exact payload. bufferSize spans values
+// below, equal to, and above the analysis window — the axis that exposed
+// BEE-2249 (bufferSize > windowSize corrupted the payload).
 // ===========================================================================
 
-TEST_CASE("RoundTrip 48000 Hz", "[roundtrip][48000]") {
-  SECTION("Audible") {
-    REQUIRE(roundTrip(BEEPING_MODE_AUDIBLE, 48000.0f, "123456789"));
-  }
-  SECTION("Inaudible") {
-    REQUIRE(roundTrip(BEEPING_MODE_INAUDIBLE, 48000.0f, "123456789"));
-  }
-  SECTION("All") {
-    REQUIRE(roundTrip(BEEPING_MODE_ALL, 48000.0f, "123456789"));
-  }
-}
+TEST_CASE("RoundTrip matrix (rate × mode × bufferSize)", "[roundtrip]") {
+  float sampleRate =
+      GENERATE(22050.0f, 24000.0f, 32000.0f, 44100.0f, 48000.0f, 96000.0f);
 
-// ===========================================================================
-// Round-trip at 44100 Hz
-// ===========================================================================
+  auto mode =
+      GENERATE(BEEPING_MODE_AUDIBLE, BEEPING_MODE_INAUDIBLE, BEEPING_MODE_ALL);
 
-TEST_CASE("RoundTrip 44100 Hz", "[roundtrip][44100]") {
-  SECTION("Audible") {
-    REQUIRE(roundTrip(BEEPING_MODE_AUDIBLE, 44100.0f, "123456789"));
-  }
-  SECTION("Inaudible") {
-    REQUIRE(roundTrip(BEEPING_MODE_INAUDIBLE, 44100.0f, "123456789"));
-  }
-  SECTION("All") {
-    REQUIRE(roundTrip(BEEPING_MODE_ALL, 44100.0f, "123456789"));
-  }
-}
+  int bufferSize = GENERATE(128, 256, 512, 1024, 2048, 4096, 8192);
 
-// ===========================================================================
-// Round-trip at 32000 Hz
-// ===========================================================================
-
-TEST_CASE("RoundTrip 32000 Hz", "[roundtrip][32000]") {
-  SECTION("Audible") {
-    REQUIRE(roundTrip(BEEPING_MODE_AUDIBLE, 32000.0f, "123456789"));
-  }
-  SECTION("Inaudible") {
-    REQUIRE(roundTrip(BEEPING_MODE_INAUDIBLE, 32000.0f, "123456789"));
-  }
-  SECTION("All") {
-    REQUIRE(roundTrip(BEEPING_MODE_ALL, 32000.0f, "123456789"));
-  }
-}
-
-// ===========================================================================
-// Round-trip at 24000 Hz
-// ===========================================================================
-
-TEST_CASE("RoundTrip 24000 Hz", "[roundtrip][24000]") {
-  SECTION("Audible") {
-    REQUIRE(roundTrip(BEEPING_MODE_AUDIBLE, 24000.0f, "123456789"));
-  }
-  SECTION("Inaudible") {
-    REQUIRE(roundTrip(BEEPING_MODE_INAUDIBLE, 24000.0f, "123456789"));
-  }
-  SECTION("All") {
-    REQUIRE(roundTrip(BEEPING_MODE_ALL, 24000.0f, "123456789"));
-  }
-}
-
-// ===========================================================================
-// Round-trip at 22050 Hz
-// ===========================================================================
-
-TEST_CASE("RoundTrip 22050 Hz", "[roundtrip][22050]") {
-  SECTION("Audible") {
-    REQUIRE(roundTrip(BEEPING_MODE_AUDIBLE, 22050.0f, "123456789"));
-  }
-  SECTION("Inaudible") {
-    REQUIRE(roundTrip(BEEPING_MODE_INAUDIBLE, 22050.0f, "123456789"));
-  }
-  SECTION("All") {
-    REQUIRE(roundTrip(BEEPING_MODE_ALL, 22050.0f, "123456789"));
-  }
+  CAPTURE(sampleRate, mode, bufferSize);
+  REQUIRE(roundTrip(mode, sampleRate, kPayload, bufferSize) == kPayload);
 }


### PR DESCRIPTION
## Summary

Two Phase 1 (beeping-core C++20) milestone tasks, bundled:

- **BEE-2249** — `fix(decoder)`: round-trip corrupted the payload whenever `bufferSize > windowSize`. The decoder wrote a full bufferSize chunk into the `windowSize*4` frame ring buffer but drained only up to the first event per call; the surplus accumulated across calls until the write lapped the unread read pointer. Fixed by draining every complete window per call (latch last non-terminal event; WORD COMPLETE still returns immediately) and sizing the ring buffer for one full chunk `max(windowSize*4, bufferSize + windowSize*2)`. Applied to NonAudible/Audible/All decoders.
- **BEE-2288** — `ci(release)`: add `linux-musl-x64` build job (alpine:3.20, static libstdc++/libgcc) + `linux-musl-compat-smoke` matrix (alpine 3.18/3.19/3.20/edge), producing `beeping-core-linux-amd64-musl.tar.zst`. Wired into hashes + release needs (cosign + SBOM + SLSA). Unblocks Alpine consumers of beeping-node + beeping-python.

## Test plan

- [x] `RoundTripTests` parametrized over sampleRate × mode × bufferSize (126 combos) — all pass
- [x] Full suite green: 276786 assertions, 64 test cases, 0 failures (0 regressions)
- [x] ASan + UBSan: 126/126 roundtrip combos clean (no memory errors / UB)
- [x] musl build validated locally in Docker: musl linkage asserted, smoke on alpine 3.18→3.20, 1.6M artifact
- [x] clang-format clean; actionlint clean on new CI jobs

Closes BEE-2249, BEE-2288

🤖 Generated with [Claude Code](https://claude.com/claude-code)