### PR TITLE
chore(conan): BEE-30 bump Conan recipe + docs to 0.8.1

### DIFF
--- a/docs/conan.md
+++ b/docs/conan.md
@@ -29,7 +29,7 @@ The ConanCenter recipe is currently in review. Track progress at:
 
 ```ini
 [requires]
-beeping-core/0.0.0
+beeping-core/0.8.1
 
 [generators]
 CMakeDeps
@@ -46,7 +46,7 @@ class MyApp(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
-        self.requires("beeping-core/0.0.0")
+        self.requires("beeping-core/0.8.1")
 ```
 
 ### Install + build
@@ -72,7 +72,7 @@ and WASM. See [docs/verifying-releases.md](verifying-releases.md) for
 download + cryptographic verification.
 
 ```bash
-RELEASE=v0.0.0
+RELEASE=v0.8.1
 ARTIFACT=beeping-core-macos-universal.tar.zst
 
 curl -LO https://github.com/beeping-io/beeping-core/releases/download/$RELEASE/$ARTIFACT
@@ -105,19 +105,19 @@ class MyApp(ConanFile):
 
     def requirements(self):
         # Reference resolved from local recipe (option 1) or git (option 2)
-        self.requires("beeping-core/0.0.0@beeping/stable")
+        self.requires("beeping-core/0.8.1@beeping/stable")
 ```
 
 Export the recipe locally from a clone of beeping-core:
 
 ```bash
-git clone --depth=1 --branch v0.0.0 https://github.com/beeping-io/beeping-core.git
+git clone --depth=1 --branch v0.8.1 https://github.com/beeping-io/beeping-core.git
 cd beeping-core
-conan export recipe/all --version=0.0.0 --user=beeping --channel=stable
+conan export recipe/all --version=0.8.1 --user=beeping --channel=stable
 ```
 
 Now `conan install .` in your project resolves
-`beeping-core/0.0.0@beeping/stable` from your local cache, builds it once,
+`beeping-core/0.8.1@beeping/stable` from your local cache, builds it once,
 and reuses the binary across builds.
 
 ### 2c — Custom Conan remote (planned)
@@ -164,15 +164,15 @@ The target `BeepingCore::BeepingCore` carries:
 When the ConanCenter recipe is merged, switch is a one-line change:
 
 ```diff
--self.requires("beeping-core/0.0.0@beeping/stable")
-+self.requires("beeping-core/0.0.0")
+-self.requires("beeping-core/0.8.1@beeping/stable")
++self.requires("beeping-core/0.8.1")
 ```
 
 Or in `conanfile.txt`:
 
 ```diff
--beeping-core/0.0.0@beeping/stable
-+beeping-core/0.0.0
+-beeping-core/0.8.1@beeping/stable
++beeping-core/0.8.1
 ```
 
 No code changes required. Same headers, same target, same ABI.
@@ -226,7 +226,7 @@ SBOM is also published per release.
 
 ### Can I pin a specific commit instead of a tag?
 
-Yes, with method 2b. Replace `--branch v0.0.0` in the `git clone` with
+Yes, with method 2b. Replace `--branch v0.8.1` in the `git clone` with
 `--branch <commit-sha>` and adjust the version string. Note that
 ConanCenter recipes only accept tagged versions.
 

--- a/recipe/all/conandata.yml
+++ b/recipe/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.0.0":
-    url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.0.0.tar.gz"
-    sha256: "1e07d7b704f324497f70e1181d00aed5b03fd51a2f68de5675a14a8ba168806d"
+  "0.8.1":
+    url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.8.1.tar.gz"
+    sha256: "794a460617170b10030d45a0633f4db850b54ab2a026d53738c8179816b13455"

--- a/recipe/config.yml
+++ b/recipe/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.0.0":
+  "0.8.1":
     folder: all


### PR DESCRIPTION
## 🐍 Bump Conan recipe 0.0.0 → 0.8.1

The in-repo Conan recipe and `docs/conan.md` still pinned the **v0.0.0**
placeholder (2026-04-15 snapshot) while the repo is at **v0.8.1**. v0.0.0
predated 34 commits of codec/decode and platform fixes — publishing it as
the "official" version would ship a known-buggy release. This aligns the
local recipe + docs with the current release and with the upstream
ConanCenter PR ([conan-io/conan-center-index#29997](https://github.com/conan-io/conan-center-index/pull/29997)), which was updated in the same pass.

### Changes
- `recipe/all/conandata.yml` — url + sha256 of `v0.8.1` (`794a4606…`)
- `recipe/config.yml` — version `0.8.1`
- `docs/conan.md` — ~10 version references bumped (Method 1, 2a/2b, migration diff, FAQ)

### Validation
- ✅ `conan create recipe/all --version=0.8.1` (C++20) — `test_package OK`
- ✅ `shared=False` and `shared=True` both pass

### Status
Refs **BEE-30** (stays In Progress — the ConanCenter PR is still blocked
on the upstream `Job scheduler / ACTION_REQUIRED` gate, an external
maintainer action). This PR only ships the local recipe/docs consistency
bump. Downstream consumers remain unblocked via GitHub Releases / vendored WASM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)